### PR TITLE
chore(deps): Update Keycloak dependencies to 26.7.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -38,7 +38,7 @@ body:
     label: Version
     description: |
       examples:
-        - **Keycloak**: 26.6.1
+        - **Keycloak**: 26.7.0
         - **This extension**: 26.0.0
     value: |
         - Keycloak:

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -29,7 +29,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keycloak_version: [ 26.2.5, 26.3.5, 26.4.7, 26.5.7, 26.6.1, latest ]
+        # Keycloak 26.7.0 renamed OrganizationScope.SINGLE to SPECIFIC, so a jar built against
+        # 26.7.0 hits NoSuchFieldError on older servers. This workflow builds the current sources,
+        # hence 26.7.0 is the floor here. matrix.yml keeps the full range: it exercises previously
+        # released extension jars, which were compiled against the Keycloak they run on.
+        keycloak_version: [ 26.7.0, latest ]
         experimental: [false]
         include:
             - keycloak_version: nightly

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keycloak_version: [ 26.2.5, 26.3.5, 26.4.7, 26.5.7, 26.6.1, latest, nightly ]
+        keycloak_version: [ 26.2.5, 26.3.5, 26.4.7, 26.5.7, 26.6.4, 26.7.0, latest, nightly ]
         extension_version: [ 26.0.0 ]
     name: KC ${{ matrix.keycloak_version }}, Extension ${{ matrix.extension_version }}
     steps:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Flexible tools and extensions for Keycloak — modular, production-ready, and developer-friendly.
 
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/sventorben/kommons?sort=semver)
-![Keycloak Dependency Version](https://img.shields.io/badge/Keycloak-26.6.1-blue)
+![Keycloak Dependency Version](https://img.shields.io/badge/Keycloak-26.7.0-blue)
 ![GitHub Release Date](https://img.shields.io/github/release-date-pre/sventorben/kommons)
 ![Github Last Commit](https://img.shields.io/github/last-commit/sventorben/kommons)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   keycloak:
     container_name: keycloak
     hostname: keycloak
-    image: quay.io/keycloak/keycloak:26.6.1
+    image: quay.io/keycloak/keycloak:26.7.0
 
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <maven.compiler.release>17</maven.compiler.release>
 
         <!-- For compilation -->
-        <version.keycloak>26.6.1</version.keycloak>
+        <version.keycloak>26.7.0</version.keycloak>
 
         <!-- For compatibility tests -->
         <keycloak.version>${version.keycloak}</keycloak.version>
@@ -287,7 +287,7 @@ Signed-off-by: GitHub Actions &lt;actions@github.com&gt;</scmDevelopmentCommitCo
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-client</artifactId>
-            <version>26.0.9</version>
+            <version>26.0.11</version>
             <scope>test</scope>
         </dependency>
         <!-- Logging -->


### PR DESCRIPTION
Updates Keycloak to 26.7.0.

- Keycloak 26.6.1 → 26.7.0: `version.keycloak`, docker-compose image, README badge, bug-report template, CI matrices
- keycloak-admin-client 26.0.9 → 26.0.11

## Note on the CI matrix floor

Keycloak 26.7.0 renamed `OrganizationScope.SINGLE` to `SPECIFIC` (verified with `javap` against both jars). A jar built against 26.7.0 therefore raises `NoSuchFieldError` on older servers.

`buildAndTest.yml` builds the current sources, so its floor is raised to 26.7.0. `matrix.yml` keeps the full 21.0.2 → 26.7.0 range, because it exercises previously *released* extension jars, each compiled against the Keycloak it runs on.

The matching `SINGLE` → `SPECIFIC` source change is not in this PR: it belongs to `orgs/OrganizationScopeEnforcerExecutor.java`, which is not yet tracked in git, and will land with that feature.

## Verification

- `mvn clean test-compile` and the unit tests pass against 26.7.0 on committed `HEAD`.
- The orgs sources were separately confirmed to compile against 26.7.0 once `SPECIFIC` is applied.
