### PR TITLE
fix(ci): publish and attest the release:perform build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,14 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # An explicit permissions block is exhaustive: every scope not listed here is denied, even
+    # those the repository default would otherwise grant.
     permissions:
-      contents: write       # create the GitHub Release / push tag
+      contents: write        # create the GitHub Release / push tag
       packages: write        # publish to GitHub Packages
       id-token: write        # build-provenance attestation
       attestations: write    # build-provenance attestation
+      pull-requests: write   # open the next-development-iteration PR
 
     steps:
     - name: Checkout
@@ -42,19 +45,23 @@ jobs:
         git push origin v${{ github.event.inputs.releaseVersion }}
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    # Publish the artifacts built by release:perform (target/checkout/target), not the
+    # separate release:prepare build in target/. Only the perform build is deployed to
+    # GitHub Packages, so attesting it keeps the Release page, SHA256SUMS and Packages
+    # all describing the same bytes.
     - name: Generate checksums
-      run: cd target && sha256sum kommons.jar > SHA256SUMS
+      run: cd target/checkout/target && sha256sum kommons.jar > SHA256SUMS
     - name: Attest build provenance
       uses: actions/attest-build-provenance@v4
       with:
-        subject-path: target/kommons.jar
+        subject-path: target/checkout/target/kommons.jar
     - name: Release to GitHub releases
       uses: softprops/action-gh-release@v3
       with:
         files: |
-          target/kommons.jar
-          target/SHA256SUMS
-          target/bom.json
+          target/checkout/target/kommons.jar
+          target/checkout/target/SHA256SUMS
+          target/checkout/target/bom.json
         body_path: "RELEASELOG.md"
         fail_on_unmatched_files: true
         tag_name: v${{ github.event.inputs.releaseVersion }}


### PR DESCRIPTION
Checksums, the provenance attestation and the release assets pointed at the `release:prepare` build in `target/`, but only the `release:perform` build in `target/checkout/target` is deployed to GitHub Packages. They now point at the perform build, so the Release page, `SHA256SUMS` and Packages all describe the same bytes.

Also adds `pull-requests: write`. The permissions block is exhaustive — every scope not listed is denied — and the existing `create-pull-request` step needs that scope.
