### PR TITLE
feat(orgs): bind every session to exactly one organization

### DIFF
--- a/docs/single_organization_per_session.md
+++ b/docs/single_organization_per_session.md
@@ -1,0 +1,306 @@
+---
+layout: default
+title: Single Organization per Session
+nav_order: 6
+---
+
+# 🏢 Single Organization per Session
+
+Keycloak's organization feature lets a user be a member of several organizations at once, and by default a token can
+carry all of them. This page describes how to bind **every session to exactly one organization**, so that:
+
+- the user picks an organization at login and cannot skip the choice,
+- no request can ask for two organizations or for all of them,
+- no request can quietly ask for none,
+- a token or assertion never names more than one organization.
+
+Three providers work together:
+
+| Provider | Type | Purpose |
+|---|---|---|
+| `kommons-orgs-scope-enforcer` | Client policy executor | Rejects requests whose `scope` does not resolve to exactly one organization |
+| `kommons-orgs-scope-injector` | Authenticator | Adds the organization scope to OpenID Connect requests that did not ask for it |
+| `kommons-orgs-select-organization` | Required action | Makes the user choose an organization for protocols without a `scope` parameter (SAML) |
+
+You do not necessarily need all three. See [Which pieces do I need?](#-which-pieces-do-i-need) below.
+
+---
+
+## 🧭 Why more than a client policy is needed
+
+It helps to know how Keycloak decides which organization a session belongs to, because the moving parts sit in two
+different places.
+
+**The login side reads the raw `scope` request parameter.** The organization selection screen is only shown when the
+request asked for the bare `organization` scope, the user is a member of more than one enabled organization, and no
+organization has been picked yet. Even the cookie authenticator consults the requested scope: when an organization
+scope is present it steps aside so the organization can be resolved before the session is reused, and when it is
+absent single sign-on completes without ever touching the organization flow.
+
+**The token side reads the granted client scopes.** The `oidc-organization-membership-mapper` resolves organizations
+from the scopes attached to the client session.
+
+That split has a consequence worth spelling out, because it is the most common wrong turn:
+
+> ⚠️ **Making the `organization` client scope a default scope does not force the selection.**
+> Default scopes are visible to the token mappers but not to the login side, which only ever looks at the `scope`
+> request parameter. A user with a single membership then still gets a correct token, while a user with several
+> memberships gets **no organization claim at all** and is never asked to choose. The failure is silent and only hits
+> multi-organization users, so it easily survives testing.
+>
+> Measured on Keycloak 26.7.0 with the scope assigned as **default** and a user in two organizations:
+> `scope=openid` → no `organization` claim, `scope=openid organization:*` → both organizations, and
+> `scope=openid organization` → **HTTP 500**. The same explicit request succeeds when the scope is assigned as
+> *optional*, so keep the organization scope optional and let the injector add it to the request.
+
+The scope injector exists precisely because rewriting the requested scope is the one change that both sides observe.
+
+---
+
+## 🚦 Client Policy Executor: `kommons-orgs-scope-enforcer`
+
+Rejects a request when its `scope` parameter does not resolve to exactly one organization.
+
+### Rules
+
+| Requested scope | Result |
+|---|---|
+| `organization` | ✅ accepted — resolves to the user's only membership, or to the one they select |
+| `organization:acme` | ✅ accepted (unless the selection mode forbids it, see below) |
+| `organization:acme organization:globex` | ❌ rejected — more than one organization |
+| `organization:*` | ❌ rejected — all organizations |
+| *(no organization scope)* | ❌ rejected, unless "Require an organization scope" is switched off |
+
+Rejections are returned as `invalid_scope` with HTTP 400.
+
+### Where it applies
+
+The executor runs on every event that carries a client supplied `scope` and can widen the organizations in a token:
+authorization requests, pushed authorization requests, CIBA backchannel authentication, device authorization, token
+refresh, token exchange, and the resource owner password credentials grant.
+
+It deliberately does **not** run on the client credentials grant: that grant has no user and therefore no organization
+membership to constrain.
+
+An empty `scope` on a **refresh** is treated as "reuse what was granted before", not as "no organization requested",
+so a normal refresh is never rejected. An explicit scope on a refresh is still checked.
+
+### Configuration
+
+| Option | Key | Type | Default |
+|---|---|---|---|
+| Require an organization scope | `kommons.orgs.require.scope` | Boolean | `true` |
+| How the organization may be selected | `kommons.orgs.selection.mode` | `any-single` \| `user-selected` | `any-single` |
+
+- **`any-single`** — the client may either request the bare `organization` scope and let the user pick, or name
+  exactly one organization with `organization:<alias>`.
+- **`user-selected`** — only the bare `organization` scope is accepted. The client can never pin an organization, so
+  the choice always belongs to the user. Use this when clients are not trusted to choose the tenant.
+
+The organization scope is not recognized by name but by its protocol mapper: any client scope carrying the
+`oidc-organization-membership-mapper` counts, which is the same rule Keycloak applies internally. If you renamed the
+scope, or defined several, they are all recognized.
+
+### Setup
+
+1. **Realm settings → Client policies → Profiles → Create client profile**, for example `single-organization`
+2. Add the executor **Organization Scope Enforcer** and configure it
+3. **Policies → Create client policy**, add the condition **any-client** and attach the profile
+
+Or import it with your realm:
+
+```json
+{
+  "clientProfiles": {
+    "profiles": [
+      {
+        "name": "single-organization",
+        "executors": [
+          {
+            "executor": "kommons-orgs-scope-enforcer",
+            "configuration": {
+              "kommons.orgs.require.scope": true,
+              "kommons.orgs.selection.mode": "any-single"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "clientPolicies": {
+    "policies": [
+      {
+        "name": "single-organization-for-all-clients",
+        "enabled": true,
+        "conditions": [{ "condition": "any-client", "configuration": {} }],
+        "profiles": ["single-organization"]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## 💉 Authenticator: `kommons-orgs-scope-injector`
+
+Adds the organization scope to an OpenID Connect authorization request that did not ask for it, so that the selection
+screen is triggered and the organization ends up in the token — **without having to change any client**.
+
+Use it when you cannot make every application request the `organization` scope. With the injector in place you can
+leave the executor's "Require an organization scope" enabled and still never reject a legacy client, because by the
+time the request is evaluated the scope is there.
+
+### Behaviour
+
+- Runs only for the `openid-connect` protocol. SAML has no `scope` parameter; use the required action instead.
+- Does nothing when the request already contains an organization scope, so a client that asks for
+  `organization:acme` keeps its choice.
+- Never authenticates anybody. It rewrites the requested scope and reports `attempted`, letting the flow continue.
+- Failures are logged and swallowed: a problem here can never block a login, the request simply behaves as before.
+
+### Configuration
+
+| Option | Key | Type | Default |
+|---|---|---|---|
+| Organization scope name | `kommons.orgs.scope.name` | String | *(empty)* |
+
+Leave it empty to use the organization client scope assigned to the client, which works whenever a client has exactly
+one. Set it explicitly if a client has several organization client scopes assigned, otherwise nothing is injected and
+a warning is logged.
+
+### Setup
+
+1. **Authentication → Flows**, duplicate the **browser** flow (built-in flows cannot be edited)
+2. **Add step → Organization Scope Injector**
+3. Move it to the **top of the flow**, above **Cookie**
+4. Set the requirement to **Alternative**
+5. Bind the flow: **Action → Bind flow → Browser flow**
+
+> ⚠️ **The step must be `Alternative` and must sit before `Cookie`.**
+> The injector must run before the cookie authenticator decides whether to complete single sign-on. It is also the
+> reason `Required` is not offered as a requirement: a required execution disables every alternative of its parent
+> flow, which would break cookie based single sign-on entirely.
+
+The organization client scope still has to be assigned to the client, as optional or default. The injector adds the
+scope to the request, it does not grant a scope the client is not allowed to use.
+
+---
+
+## 🧑‍💼 Required Action: `kommons-orgs-select-organization`
+
+Makes the user pick exactly one organization for login protocols that have no `scope` parameter, above all **SAML**.
+
+Keycloak's own selection screen is driven by the organization scope and is therefore unreachable for a SAML client.
+Required actions on the other hand are evaluated on **every** authentication regardless of protocol, including a login
+that reuses an existing single sign-on session, which makes this the one hook that cannot be bypassed.
+
+### Behaviour
+
+- Skips OpenID Connect entirely — that is covered by Keycloak's organization authenticator together with the
+  injector. Without this guard the user would be asked twice.
+- Skips when an organization has already been selected for the client session.
+- Selects silently when the user is a member of exactly one enabled organization.
+- Shows the selection screen when the user is a member of several, reusing Keycloak's own `select-organization.ftl`
+  from the base login theme, so no custom theme is needed.
+- Validates the submitted alias against the user's enabled memberships before accepting it.
+
+The chosen organization is written to the `kc.org` client note — the very note Keycloak's browser flow uses. It
+reaches the authenticated client session through Keycloak's regular note transfer, which is protocol independent.
+
+### Setup
+
+**Authentication → Required actions**, then set **Select Organization** to *Enabled*.
+
+Leave **Set as default action** **off**. The action is triggered by its own evaluation on every login, not by being
+assigned to users.
+
+### Reading the selection in a SAML mapper
+
+Keycloak's built-in SAML organization mapper (`saml-organization-membership-mapper`) writes **every** organization the
+user belongs to as a multi-valued attribute. It ignores the selection completely. To emit a single organization you
+need your own `SAMLAttributeStatementMapper`:
+
+```java
+@Override
+public void transformAttributeStatement(AttributeStatementType statement, ProtocolMapperModel model,
+        KeycloakSession session, UserSessionModel userSession, AuthenticatedClientSessionModel clientSession) {
+
+    String organizationId = clientSession.getNote(OrganizationModel.ORGANIZATION_ATTRIBUTE);
+    if (organizationId == null) {
+        return; // fail closed: no selection means no organization attribute
+    }
+    // resolve the organization, re-check isEnabled() and isMember(user), then add a single attribute value
+}
+```
+
+Two things to get right:
+
+- **Fail closed on a missing note.** Do not fall back to "all memberships", or the one path that bypassed the
+  selection silently produces the multi-organization assertion you are trying to prevent.
+- **Do not read `session.getContext().getOrganization()`.** It is only populated when Keycloak's organization
+  authenticator actually ran, which is not the case on the single sign-on path nor when this required action made the
+  choice.
+
+> ⚠️ Remove the built-in SAML organization mapper from those clients. If both are attached, the assertion contains
+> your single value **and** the full list.
+
+---
+
+## 🧩 Which pieces do I need?
+
+| Situation | Enforcer | Injector | Required action |
+|---|---|---|---|
+| OIDC only, all clients request `organization` | ✅ | — | — |
+| OIDC only, clients cannot be changed | ✅ | ✅ | — |
+| SAML clients involved | ✅ (no effect on SAML) | ✅ for the OIDC clients | ✅ |
+
+The enforcer is the only piece that rejects anything, and it has no effect on SAML: SAML has no `scope` parameter, so
+there is nothing for it to validate.
+
+---
+
+## ⚠️ Limitations
+
+**The choice is per client session, not per single sign-on session.** Keycloak stores the selected organization in a
+client note. Two clients in one single sign-on session can therefore end up on two different organizations. Each
+individual token still names exactly one organization, and the user chose deliberately both times, so "one
+organization per token" holds. If your requirement is stricter and means one organization for the whole single
+sign-on session, you need to pin the selection on the user session — note that doing so also removes the ability to
+switch organizations without a full logout.
+
+**Switching organizations means a new authorization request.** Because a new authorization request starts a fresh
+authentication session whose client notes are empty, a user who is a member of several organizations is asked again.
+That is the switching mechanism; no logout is required.
+
+**Disabled organizations may appear on the selection screen.** The reused `select-organization.ftl` lists the user's
+memberships without filtering by enabled state. This matches Keycloak's own behaviour. A disabled organization is
+rejected on submit.
+
+**The client credentials grant is out of scope.** Service accounts have no organization membership, so nothing is
+enforced there.
+
+---
+
+## 🧪 Verifying the setup
+
+**Rejection rules** can be checked without a browser using the resource owner password credentials grant:
+
+```bash
+# rejected: two organizations
+curl -d grant_type=password -d client_id=my-client -d username=alice -d password=... \
+     -d 'scope=openid organization:acme organization:globex' \
+     https://<host>/realms/<realm>/protocol/openid-connect/token
+# => 400 {"error":"invalid_scope", ...}
+
+# rejected: all organizations
+... -d 'scope=openid organization:*'
+
+# accepted
+... -d 'scope=openid organization:acme'
+```
+
+**The selection screen** needs a browser login with a user who is a member of more than one enabled organization.
+With the injector active, a client that requests no scope at all should still land on the organization selection.
+
+**The resulting claim** is best inspected in **Clients → *your client* → Client scopes → Evaluate**.

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeEnforcerExecutor.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeEnforcerExecutor.java
@@ -1,0 +1,142 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.grants.device.clientpolicy.context.DeviceAuthorizationRequestContext;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyEvent;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.context.ClientModelContext;
+import org.keycloak.services.clientpolicy.context.ScopeParameterContext;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Rejects requests whose {@code scope} parameter does not resolve to exactly one organization.
+ *
+ * @see OrganizationScopeEnforcerExecutorFactory
+ */
+class OrganizationScopeEnforcerExecutor implements ClientPolicyExecutorProvider<OrganizationScopeEnforcerExecutorConfiguration> {
+
+    private static final Logger LOG = Logger.getLogger(OrganizationScopeEnforcerExecutor.class);
+
+    /**
+     * Events carrying a client supplied {@code scope} parameter that can widen the organizations in a token.
+     *
+     * <p>{@code SERVICE_ACCOUNT_TOKEN_REQUEST} is deliberately absent: the client credentials grant has no user and
+     * therefore no organization membership to constrain.
+     */
+    private static final Set<ClientPolicyEvent> ENFORCED_EVENTS = EnumSet.of(
+        ClientPolicyEvent.AUTHORIZATION_REQUEST,
+        ClientPolicyEvent.PUSHED_AUTHORIZATION_REQUEST,
+        ClientPolicyEvent.BACKCHANNEL_AUTHENTICATION_REQUEST,
+        ClientPolicyEvent.DEVICE_AUTHORIZATION_REQUEST,
+        ClientPolicyEvent.TOKEN_REFRESH,
+        ClientPolicyEvent.TOKEN_EXCHANGE_REQUEST,
+        ClientPolicyEvent.RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST);
+
+    private final KeycloakSession session;
+    private OrganizationScopeEnforcerExecutorConfiguration configuration;
+
+    OrganizationScopeEnforcerExecutor(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public void setupConfiguration(OrganizationScopeEnforcerExecutorConfiguration config) {
+        configuration = Objects.requireNonNullElseGet(config,
+            OrganizationScopeEnforcerExecutorConfiguration::new).parseWithDefaultValues();
+    }
+
+    @Override
+    public Class<OrganizationScopeEnforcerExecutorConfiguration> getExecutorConfigurationClass() {
+        return OrganizationScopeEnforcerExecutorConfiguration.class;
+    }
+
+    @Override
+    public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
+        ClientPolicyEvent event = context.getEvent();
+        if (!ENFORCED_EVENTS.contains(event)) {
+            return;
+        }
+
+        if (event == ClientPolicyEvent.DEVICE_AUTHORIZATION_REQUEST) {
+            // The only enforced context that exposes neither the client nor the scope parameter directly.
+            DeviceAuthorizationRequestContext deviceContext = (DeviceAuthorizationRequestContext) context;
+            validate(session.getContext().getClient(), deviceContext.getRequest().getScope(), false);
+            return;
+        }
+
+        ClientModel client = ((ClientModelContext) context).getClient();
+        String rawScope = ((ScopeParameterContext) context).getScopeParameter();
+        validate(client, rawScope, event == ClientPolicyEvent.TOKEN_REFRESH);
+    }
+
+    /**
+     * @param absentScopeIsInherited whether an empty {@code scope} parameter means "keep what was granted before"
+     *                               rather than "ask for nothing", which is the case when refreshing a token
+     */
+    private void validate(ClientModel client, String rawScope, boolean absentScopeIsInherited) throws ClientPolicyException {
+        if (client == null) {
+            // Without a client the assigned organization client scopes cannot be resolved. Leave the request to
+            // Keycloak rather than rejecting something that was never classified.
+            LOG.debug("Cannot resolve the client of the request, skipping organization scope enforcement");
+            return;
+        }
+
+        List<OrganizationScopes.Requested> requested = OrganizationScopes.parse(client, rawScope);
+
+        if (requested.isEmpty()) {
+            validateNoneRequested(rawScope, absentScopeIsInherited);
+        } else if (requested.size() > 1) {
+            throw invalidScope("Only a single organization scope may be requested, but " + requested.size()
+                + " were found: " + requested.stream().map(OrganizationScopes.Requested::rawValue).toList() + ".");
+        } else {
+            validateSingleRequested(requested.get(0));
+        }
+    }
+
+    private void validateNoneRequested(String rawScope, boolean absentScopeIsInherited) throws ClientPolicyException {
+        boolean inherited = absentScopeIsInherited && (rawScope == null || rawScope.isBlank());
+
+        if (inherited || !configuration.isRequireScope()) {
+            return;
+        }
+
+        throw invalidScope("An organization scope is required, but the request contains none.");
+    }
+
+    private void validateSingleRequested(OrganizationScopes.Requested single) throws ClientPolicyException {
+        if (OrganizationScopes.Kind.ALL == single.kind()) {
+            throw invalidScope("Requesting all organizations via '" + single.rawValue() + "' is not allowed.");
+        }
+
+        if (OrganizationScopes.Kind.SPECIFIC == single.kind() && configuration.isUserSelectedOnly()) {
+            throw invalidScope("The organization must be selected by the user. Request '" + single.scopeName()
+                + "' without a value instead of '" + single.rawValue() + "'.");
+        }
+
+        // Anything left resolves to a single organization: the user's only membership or the one they select.
+    }
+
+    private ClientPolicyException invalidScope(String detail) {
+        return new ClientPolicyException(OAuthErrorException.INVALID_SCOPE, detail, Response.Status.BAD_REQUEST);
+    }
+
+    @Override
+    public String getName() {
+        return "Organization Scope Enforcer";
+    }
+
+    @Override
+    public String getProviderId() {
+        return OrganizationScopeEnforcerExecutorFactory.PROVIDER_ID;
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeEnforcerExecutorConfiguration.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeEnforcerExecutorConfiguration.java
@@ -1,0 +1,54 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+
+class OrganizationScopeEnforcerExecutorConfiguration extends ClientPolicyExecutorConfigurationRepresentation {
+
+    static final String CONFIG_REQUIRE_SCOPE = "kommons.orgs.require.scope";
+    static final String CONFIG_SELECTION_MODE = "kommons.orgs.selection.mode";
+
+    /** Accept either the bare organization scope or a single {@code organization:<alias>}. */
+    static final String MODE_ANY_SINGLE = "any-single";
+
+    /** Accept only the bare organization scope, so the organization is always chosen by the user. */
+    static final String MODE_USER_SELECTED = "user-selected";
+
+    @JsonProperty(CONFIG_REQUIRE_SCOPE)
+    private Boolean requireScope;
+
+    @JsonProperty(CONFIG_SELECTION_MODE)
+    private String selectionMode;
+
+    boolean isRequireScope() {
+        return Boolean.TRUE.equals(requireScope);
+    }
+
+    boolean isUserSelectedOnly() {
+        return MODE_USER_SELECTED.equals(selectionMode);
+    }
+
+    /**
+     * Deliberately not named {@code setRequireScope}: Jackson picks up non-public setters, which would add a second
+     * property alongside the one the {@link JsonProperty} annotated field already declares.
+     */
+    OrganizationScopeEnforcerExecutorConfiguration withRequireScope(boolean value) {
+        this.requireScope = value;
+        return this;
+    }
+
+    OrganizationScopeEnforcerExecutorConfiguration withSelectionMode(String value) {
+        this.selectionMode = value;
+        return this;
+    }
+
+    OrganizationScopeEnforcerExecutorConfiguration parseWithDefaultValues() {
+        if (requireScope == null) {
+            requireScope = Boolean.TRUE;
+        }
+        if (selectionMode == null || selectionMode.isBlank()) {
+            selectionMode = MODE_ANY_SINGLE;
+        }
+        return this;
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeEnforcerExecutorFactory.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeEnforcerExecutorFactory.java
@@ -1,0 +1,89 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import org.keycloak.Config;
+import org.keycloak.common.Profile;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static de.sventorben.keycloak.kommons.orgs.OrganizationScopeEnforcerExecutorConfiguration.CONFIG_REQUIRE_SCOPE;
+import static de.sventorben.keycloak.kommons.orgs.OrganizationScopeEnforcerExecutorConfiguration.CONFIG_SELECTION_MODE;
+import static de.sventorben.keycloak.kommons.orgs.OrganizationScopeEnforcerExecutorConfiguration.MODE_ANY_SINGLE;
+import static de.sventorben.keycloak.kommons.orgs.OrganizationScopeEnforcerExecutorConfiguration.MODE_USER_SELECTED;
+
+public final class OrganizationScopeEnforcerExecutorFactory implements ClientPolicyExecutorProviderFactory {
+
+    static final String PROVIDER_ID = "kommons-orgs-scope-enforcer";
+
+    @Override
+    public String getHelpText() {
+        return "Rejects requests whose scope parameter does not resolve to exactly one organization. "
+            + "Requesting all organizations (organization:*) or several organization scopes at once is refused, "
+            + "and requests without any organization scope can be refused as well. "
+            + "Intended for multi-tenant environments that bind every session to a single organization.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
+        ProviderConfigProperty requireScope = new ProviderConfigProperty();
+        requireScope.setName(CONFIG_REQUIRE_SCOPE);
+        requireScope.setLabel("Require an organization scope");
+        requireScope.setHelpText("If enabled, requests that do not carry any organization scope are rejected. "
+            + "Disable this only if some clients are allowed to obtain tokens without an organization. "
+            + "Note that a refresh request without a scope parameter reuses the previously granted scopes "
+            + "and is never rejected by this rule.");
+        requireScope.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        requireScope.setDefaultValue(Boolean.TRUE.toString());
+        requireScope.setRequired(true);
+        configProperties.add(requireScope);
+
+        ProviderConfigProperty selectionMode = new ProviderConfigProperty();
+        selectionMode.setName(CONFIG_SELECTION_MODE);
+        selectionMode.setLabel("How the organization may be selected");
+        selectionMode.setHelpText("'" + MODE_ANY_SINGLE + "': the client may either request the bare organization "
+            + "scope and let the user pick, or name exactly one organization (organization:<alias>). "
+            + "'" + MODE_USER_SELECTED + "': only the bare organization scope is accepted, so the organization is "
+            + "always chosen by the user and can never be pinned by the client.");
+        selectionMode.setType(ProviderConfigProperty.LIST_TYPE);
+        selectionMode.setOptions(List.of(MODE_ANY_SINGLE, MODE_USER_SELECTED));
+        selectionMode.setDefaultValue(MODE_ANY_SINGLE);
+        selectionMode.setRequired(true);
+        configProperties.add(selectionMode);
+
+        return configProperties;
+    }
+
+    @Override
+    public ClientPolicyExecutorProvider<?> create(KeycloakSession keycloakSession) {
+        return new OrganizationScopeEnforcerExecutor(keycloakSession);
+    }
+
+    @Override
+    public void init(Config.Scope scope) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory keycloakSessionFactory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION);
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeInjectorAuthenticator.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeInjectorAuthenticator.java
@@ -1,0 +1,145 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Adds the organization scope to an authorization request that did not ask for it, so that a session is always
+ * established in the context of an organization &mdash; without having to change any client.
+ *
+ * <p>Keycloak gates its organization handling on the requested {@code scope} parameter. The cookie authenticator
+ * yields to the {@code Organization} sub-flow only when an organization scope was requested, and the organization
+ * selection screen is only shown for the bare organization scope. Assigning the organization client scope as a
+ * <em>default</em> scope does not help: the login side reads the raw {@code scope} request parameter, while only the
+ * token mappers see the assigned client scopes. Rewriting the request parameter is therefore the one place that
+ * influences both.
+ *
+ * <p>This authenticator never authenticates anybody. It rewrites the note and reports
+ * {@link AuthenticationFlowContext#attempted()}, so it must be added as an {@code ALTERNATIVE} execution ahead of the
+ * cookie authenticator.
+ */
+final class OrganizationScopeInjectorAuthenticator implements Authenticator {
+
+    private static final Logger LOG = Logger.getLogger(OrganizationScopeInjectorAuthenticator.class);
+
+    static final String CONFIG_SCOPE_NAME = "kommons.orgs.scope.name";
+
+    /** Stateless, so a single instance is shared by the factory. */
+    static final OrganizationScopeInjectorAuthenticator INSTANCE = new OrganizationScopeInjectorAuthenticator();
+
+    private OrganizationScopeInjectorAuthenticator() {
+    }
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        try {
+            inject(context);
+        } catch (RuntimeException e) {
+            // Never let a failure here block a login: without the scope the request simply behaves as before.
+            LOG.warn("Failed to inject the organization scope, continuing without it", e);
+        }
+        context.attempted();
+    }
+
+    private void inject(AuthenticationFlowContext context) {
+        if (!context.getRealm().isOrganizationsEnabled()) {
+            return;
+        }
+
+        AuthenticationSessionModel authSession = context.getAuthenticationSession();
+
+        if (!OIDCLoginProtocol.LOGIN_PROTOCOL.equals(authSession.getProtocol())) {
+            // Only OpenID Connect has a scope parameter. For SAML use the "Select Organization" required action.
+            return;
+        }
+
+        ClientModel client = authSession.getClient();
+        String requestedScope = authSession.getClientNote(OIDCLoginProtocol.SCOPE_PARAM);
+
+        if (!OrganizationScopes.parse(client, requestedScope).isEmpty()) {
+            LOG.debugf("Client %s already requested an organization scope, nothing to inject", client.getClientId());
+            return;
+        }
+
+        String scopeName = resolveScopeName(context, client);
+        if (scopeName == null) {
+            return;
+        }
+
+        String updatedScope = requestedScope == null || requestedScope.isBlank()
+            ? scopeName
+            : requestedScope + " " + scopeName;
+        authSession.setClientNote(OIDCLoginProtocol.SCOPE_PARAM, updatedScope);
+
+        LOG.debugf("Injected organization scope '%s' for client %s", scopeName, client.getClientId());
+    }
+
+    /**
+     * Returns the organization client scope to request, either from the authenticator config or, when unset, from
+     * the single organization client scope assigned to the client.
+     */
+    private String resolveScopeName(AuthenticationFlowContext context, ClientModel client) {
+        String configured = configuredScopeName(context);
+        if (configured != null) {
+            return configured;
+        }
+
+        Set<String> assigned = OrganizationScopes.organizationScopeNames(client);
+        if (assigned.size() == 1) {
+            return assigned.iterator().next();
+        }
+
+        if (assigned.isEmpty()) {
+            LOG.debugf("Client %s has no organization client scope assigned, nothing to inject",
+                client.getClientId());
+        } else {
+            LOG.warnf("Client %s has %d organization client scopes assigned (%s). Configure '%s' on the "
+                    + "authenticator to choose one, no scope was injected.",
+                client.getClientId(), assigned.size(), assigned, CONFIG_SCOPE_NAME);
+        }
+        return null;
+    }
+
+    private String configuredScopeName(AuthenticationFlowContext context) {
+        return Optional.ofNullable(context.getAuthenticatorConfig())
+            .map(AuthenticatorConfigModel::getConfig)
+            .map(config -> config.get(CONFIG_SCOPE_NAME))
+            .filter(value -> !value.isBlank())
+            .map(String::trim)
+            .orElse(null);
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+        context.attempted();
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return false;
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return true;
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeInjectorAuthenticatorFactory.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeInjectorAuthenticatorFactory.java
@@ -1,0 +1,102 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.common.Profile;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.List;
+
+import static de.sventorben.keycloak.kommons.orgs.OrganizationScopeInjectorAuthenticator.CONFIG_SCOPE_NAME;
+
+public final class OrganizationScopeInjectorAuthenticatorFactory
+    implements AuthenticatorFactory, EnvironmentDependentProviderFactory {
+
+    static final String PROVIDER_ID = "kommons-orgs-scope-injector";
+
+    /**
+     * The authenticator only ever reports {@code attempted}, so it must not be {@code REQUIRED}: a required execution
+     * disables every alternative of its parent flow and would break cookie based single sign-on.
+     */
+    private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+        AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+        AuthenticationExecutionModel.Requirement.DISABLED
+    };
+
+    @Override
+    public String getDisplayType() {
+        return "Organization Scope Injector";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return "organization";
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Adds the organization scope to OpenID Connect authorization requests that did not ask for it, so "
+            + "that the organization selection is triggered and the organization ends up in the token even for "
+            + "clients that cannot be changed. Add this as the first ALTERNATIVE execution of the browser flow, "
+            + "before the cookie authenticator.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        ProviderConfigProperty scopeName = new ProviderConfigProperty();
+        scopeName.setName(CONFIG_SCOPE_NAME);
+        scopeName.setLabel("Organization scope name");
+        scopeName.setHelpText("Name of the client scope to request, for example 'organization'. Leave empty to use "
+            + "the organization client scope assigned to the client, which works whenever a client has exactly one.");
+        scopeName.setType(ProviderConfigProperty.STRING_TYPE);
+        scopeName.setRequired(false);
+        return List.of(scopeName);
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return OrganizationScopeInjectorAuthenticator.INSTANCE;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION);
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopes.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopes.java
@@ -1,0 +1,127 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.organization.protocol.mappers.oidc.OrganizationMembershipMapper;
+import org.keycloak.protocol.oidc.TokenManager;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Classifies the organization related entries of an OAuth {@code scope} parameter.
+ *
+ * <p>Keycloak's own {@link org.keycloak.organization.protocol.mappers.oidc.OrganizationScope} can only report the
+ * <em>first</em> organization scope it finds, which is not enough to detect that a client asked for several of them.
+ * This class applies the same recognition rule &mdash; a client scope is an organization scope when it carries the
+ * {@code oidc-organization-membership-mapper} &mdash; but keeps every match, so callers can count them.
+ *
+ * <p>Resolution deliberately goes through the {@link ClientModel} rather than
+ * {@code session.getContext().getClient()}, because the client is not guaranteed to be on the Keycloak context in
+ * every client policy event.
+ */
+final class OrganizationScopes {
+
+    /**
+     * Value of a parameterized organization scope that maps to every organization the user is a member of,
+     * i.e. {@code organization:*}.
+     */
+    private static final String ALL_ORGANIZATIONS = "*";
+
+    private OrganizationScopes() {
+    }
+
+    /**
+     * Returns the organization scopes contained in {@code rawScope}, in the order they were requested.
+     *
+     * @param client     the client the request was made for, may be {@code null}
+     * @param rawScope   the raw {@code scope} parameter, may be {@code null} or blank
+     * @return the recognized organization scopes, never {@code null}
+     */
+    static List<Requested> parse(ClientModel client, String rawScope) {
+        if (isBlank(rawScope)) {
+            return List.of();
+        }
+
+        Set<String> scopeNames = organizationScopeNames(client);
+        if (scopeNames.isEmpty()) {
+            return List.of();
+        }
+
+        return TokenManager.parseScopeParameter(rawScope)
+            .map(entry -> classify(scopeNames, entry))
+            .filter(Objects::nonNull)
+            .toList();
+    }
+
+    /**
+     * Names of the client scopes assigned to {@code client} (default and optional) that map organization membership.
+     */
+    static Set<String> organizationScopeNames(ClientModel client) {
+        if (client == null) {
+            return Set.of();
+        }
+        return Stream.concat(
+                client.getClientScopes(true).values().stream(),
+                client.getClientScopes(false).values().stream())
+            .filter(OrganizationScopes::mapsOrganizations)
+            .map(ClientScopeModel::getName)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private static Requested classify(Set<String> scopeNames, String entry) {
+        for (String scopeName : scopeNames) {
+            if (entry.equals(scopeName)) {
+                return new Requested(entry, scopeName, Kind.ANY);
+            }
+
+            String prefix = scopeName + ClientScopeModel.VALUE_SEPARATOR;
+            if (entry.startsWith(prefix)) {
+                String value = entry.substring(prefix.length());
+                return new Requested(entry, scopeName, ALL_ORGANIZATIONS.equals(value) ? Kind.ALL : Kind.SPECIFIC);
+            }
+        }
+        return null;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static boolean mapsOrganizations(ClientScopeModel clientScope) {
+        return clientScope.getProtocolMappersStream()
+            .map(ProtocolMapperModel::getProtocolMapper)
+            .anyMatch(OrganizationMembershipMapper.PROVIDER_ID::equals);
+    }
+
+    /**
+     * How a requested organization scope maps to organizations. Mirrors
+     * {@link org.keycloak.organization.protocol.mappers.oidc.OrganizationScope}.
+     */
+    enum Kind {
+
+        /** {@code organization} &mdash; resolved from the user's single membership or from the user's selection. */
+        ANY,
+
+        /** {@code organization:<alias>} &mdash; a specific organization named by the client. */
+        SPECIFIC,
+
+        /** {@code organization:*} &mdash; every organization the user is a member of. */
+        ALL
+    }
+
+    /**
+     * A single organization scope found in a {@code scope} parameter.
+     *
+     * @param rawValue  the entry as requested, e.g. {@code organization:acme}
+     * @param scopeName the name of the underlying client scope, e.g. {@code organization}
+     * @param kind      how the entry maps to organizations
+     */
+    record Requested(String rawValue, String scopeName, Kind kind) {
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/SelectOrganizationRequiredAction.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/SelectOrganizationRequiredAction.java
@@ -1,0 +1,133 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.RequiredActionContext;
+import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.email.freemarker.beans.ProfileBean;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.services.messages.Messages;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import java.util.List;
+
+/**
+ * Makes the user pick exactly one organization for protocols that have no {@code scope} parameter, above all SAML.
+ *
+ * <p>Keycloak's own organization selection screen is driven by the requested organization scope and is therefore
+ * unreachable for a SAML client. Required actions on the other hand are evaluated on every authentication regardless
+ * of the login protocol, including a login that reuses an existing single sign-on session, which makes this the one
+ * hook that cannot be bypassed.
+ *
+ * <p>The selected organization is written to the {@code kc.org} client note, the very note Keycloak's browser flow
+ * uses. It reaches the authenticated client session through the regular note transfer, so a protocol mapper can read
+ * it with {@code clientSession.getNote(OrganizationModel.ORGANIZATION_ATTRIBUTE)}.
+ */
+final class SelectOrganizationRequiredAction implements RequiredActionProvider {
+
+    private static final Logger LOG = Logger.getLogger(SelectOrganizationRequiredAction.class);
+
+    /** Shipped by Keycloak's base login theme and also used by the built-in organization selection. */
+    private static final String FORM_TEMPLATE = "select-organization.ftl";
+
+    /** Stateless, so a single instance is shared by the factory. */
+    static final SelectOrganizationRequiredAction INSTANCE = new SelectOrganizationRequiredAction();
+
+    private SelectOrganizationRequiredAction() {
+    }
+
+    @Override
+    public void evaluateTriggers(RequiredActionContext context) {
+        if (!context.getRealm().isOrganizationsEnabled()) {
+            return;
+        }
+
+        AuthenticationSessionModel authSession = context.getAuthenticationSession();
+
+        if (OIDCLoginProtocol.LOGIN_PROTOCOL.equals(authSession.getProtocol())) {
+            // OpenID Connect is covered by Keycloak's own organization authenticator, which drives the selection from
+            // the organization scope. Triggering here as well would ask the user twice.
+            return;
+        }
+
+        if (authSession.getClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE) != null) {
+            return;
+        }
+
+        List<OrganizationModel> organizations = memberships(context);
+
+        if (organizations.size() == 1) {
+            select(authSession, organizations.get(0));
+        } else if (organizations.size() > 1) {
+            authSession.addRequiredAction(SelectOrganizationRequiredActionFactory.PROVIDER_ID);
+        }
+    }
+
+    @Override
+    public void requiredActionChallenge(RequiredActionContext context) {
+        context.challenge(createForm(context, null));
+    }
+
+    @Override
+    public void processAction(RequiredActionContext context) {
+        String alias = context.getHttpRequest().getDecodedFormParameters()
+            .getFirst(OrganizationModel.ORGANIZATION_ATTRIBUTE);
+
+        OrganizationModel organization = memberships(context).stream()
+            .filter(candidate -> candidate.getAlias().equals(alias))
+            .findFirst()
+            .orElse(null);
+
+        if (organization == null) {
+            // Either nothing was submitted or the alias does not belong to an enabled organization of this user.
+            LOG.debugf("Rejected organization selection '%s' for user %s", alias, context.getUser().getUsername());
+            context.challenge(createForm(context, Messages.INVALID_REQUEST));
+            return;
+        }
+
+        select(context.getAuthenticationSession(), organization);
+        context.success();
+    }
+
+    private void select(AuthenticationSessionModel authSession, OrganizationModel organization) {
+        authSession.setClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE, organization.getId());
+        LOG.debugf("Bound the session to organization '%s'", organization.getAlias());
+    }
+
+    /**
+     * The enabled organizations the authenticating user is a member of.
+     */
+    private List<OrganizationModel> memberships(RequiredActionContext context) {
+        KeycloakSession session = context.getSession();
+        UserModel user = context.getUser();
+
+        if (user == null) {
+            return List.of();
+        }
+
+        return session.getProvider(OrganizationProvider.class)
+            .getByMember(user)
+            .filter(OrganizationModel::isEnabled)
+            .toList();
+    }
+
+    private Response createForm(RequiredActionContext context, String errorMessage) {
+        LoginFormsProvider form = context.form()
+            .setAttribute("user", new ProfileBean(context.getUser(), context.getSession()));
+
+        if (errorMessage != null) {
+            form.setError(errorMessage);
+        }
+
+        return form.createForm(FORM_TEMPLATE);
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/SelectOrganizationRequiredActionFactory.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/SelectOrganizationRequiredActionFactory.java
@@ -1,0 +1,56 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.RequiredActionFactory;
+import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.common.Profile;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+
+public final class SelectOrganizationRequiredActionFactory
+    implements RequiredActionFactory, EnvironmentDependentProviderFactory {
+
+    static final String PROVIDER_ID = "kommons-orgs-select-organization";
+
+    @Override
+    public String getDisplayText() {
+        return "Select Organization";
+    }
+
+    /**
+     * The organization is chosen per client session, so the action has to be evaluated on every authentication and
+     * must never be marked as completed for good.
+     */
+    @Override
+    public boolean isOneTimeAction() {
+        return false;
+    }
+
+    @Override
+    public RequiredActionProvider create(KeycloakSession session) {
+        return SelectOrganizationRequiredAction.INSTANCE;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION);
+    }
+}

--- a/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,1 +1,2 @@
 de.sventorben.keycloak.kommons.auth.UnusualLoginTimeConditionalAuthenticatorFactory
+de.sventorben.keycloak.kommons.orgs.OrganizationScopeInjectorAuthenticatorFactory

--- a/src/main/resources/META-INF/services/org.keycloak.authentication.RequiredActionFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.authentication.RequiredActionFactory
@@ -1,0 +1,1 @@
+de.sventorben.keycloak.kommons.orgs.SelectOrganizationRequiredActionFactory

--- a/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -1,0 +1,1 @@
+de.sventorben.keycloak.kommons.orgs.OrganizationScopeEnforcerExecutorFactory

--- a/src/test/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeEnforcerExecutorTest.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeEnforcerExecutorTest.java
@@ -1,0 +1,166 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.organization.protocol.mappers.oidc.OrganizationMembershipMapper;
+import org.keycloak.services.clientpolicy.ClientPolicyEvent;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.context.AuthorizationRequestContext;
+import org.keycloak.services.clientpolicy.context.TokenRefreshContext;
+
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the rules the executor applies to a {@code scope} parameter. The wiring into the various endpoints
+ * is exercised by {@link OrganizationScopeEnforcerIT} against a running Keycloak.
+ */
+class OrganizationScopeEnforcerExecutorTest {
+
+    private final ClientModel client = organizationAwareClient();
+
+    @Test
+    void acceptsTheBareOrganizationScope() {
+        assertThatCode(() -> authorizationRequest(defaults(), "openid organization"))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void acceptsASingleNamedOrganization() {
+        assertThatCode(() -> authorizationRequest(defaults(), "openid organization:acme"))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsSeveralOrganizationScopes() {
+        assertThatThrownBy(() -> authorizationRequest(defaults(), "openid organization:acme organization:globex"))
+            .isInstanceOf(ClientPolicyException.class)
+            .satisfies(rejectedWith("Only a single organization scope"));
+    }
+
+    @Test
+    void rejectsAllOrganizations() {
+        assertThatThrownBy(() -> authorizationRequest(defaults(), "openid organization:*"))
+            .isInstanceOf(ClientPolicyException.class)
+            .satisfies(rejectedWith("all organizations"));
+    }
+
+    @Test
+    void rejectsAMissingOrganizationScope() {
+        assertThatThrownBy(() -> authorizationRequest(defaults(), "openid profile"))
+            .isInstanceOf(ClientPolicyException.class)
+            .satisfies(rejectedWith("required"));
+    }
+
+    @Test
+    void acceptsAMissingOrganizationScopeWhenNotRequired() {
+        OrganizationScopeEnforcerExecutorConfiguration config = defaults().withRequireScope(false);
+
+        assertThatCode(() -> authorizationRequest(config, "openid profile")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsANamedOrganizationWhenOnlyUserSelectionIsAllowed() {
+        OrganizationScopeEnforcerExecutorConfiguration config = defaults()
+            .withSelectionMode(OrganizationScopeEnforcerExecutorConfiguration.MODE_USER_SELECTED);
+
+        assertThatThrownBy(() -> authorizationRequest(config, "openid organization:acme"))
+            .isInstanceOf(ClientPolicyException.class)
+            .satisfies(rejectedWith("selected by the user"));
+        assertThatCode(() -> authorizationRequest(config, "openid organization")).doesNotThrowAnyException();
+    }
+
+    /**
+     * The message of a {@link ClientPolicyException} is the OAuth error code, the human readable reason is carried
+     * separately as the error detail.
+     */
+    private static Consumer<Throwable> rejectedWith(String expectedDetail) {
+        return thrown -> {
+            ClientPolicyException exception = (ClientPolicyException) thrown;
+            assertThat(exception.getError()).isEqualTo(OAuthErrorException.INVALID_SCOPE);
+            assertThat(exception.getErrorStatus()).isEqualTo(Response.Status.BAD_REQUEST);
+            assertThat(exception.getErrorDetail()).contains(expectedDetail);
+        };
+    }
+
+    @Test
+    void treatsAnEmptyScopeOnRefreshAsInherited() {
+        assertThatCode(() -> tokenRefresh(defaults(), null)).doesNotThrowAnyException();
+        assertThatCode(() -> tokenRefresh(defaults(), "")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void stillNarrowsAnExplicitScopeOnRefresh() {
+        assertThatThrownBy(() -> tokenRefresh(defaults(), "openid organization:*"))
+            .isInstanceOf(ClientPolicyException.class);
+    }
+
+    @Test
+    void ignoresEventsWithoutAScopeParameter() throws ClientPolicyException {
+        OrganizationScopeEnforcerExecutor executor = executor(defaults());
+
+        assertThatCode(() -> executor.executeOnEvent(() -> ClientPolicyEvent.TOKEN_REVOKE))
+            .doesNotThrowAnyException();
+    }
+
+    private void authorizationRequest(OrganizationScopeEnforcerExecutorConfiguration config, String scope)
+        throws ClientPolicyException {
+        AuthorizationRequestContext context = mock(AuthorizationRequestContext.class);
+        when(context.getEvent()).thenReturn(ClientPolicyEvent.AUTHORIZATION_REQUEST);
+        when(context.getClient()).thenReturn(client);
+        when(context.getScopeParameter()).thenReturn(scope);
+
+        executor(config).executeOnEvent(context);
+    }
+
+    private void tokenRefresh(OrganizationScopeEnforcerExecutorConfiguration config, String scope)
+        throws ClientPolicyException {
+        TokenRefreshContext context = mock(TokenRefreshContext.class);
+        when(context.getEvent()).thenReturn(ClientPolicyEvent.TOKEN_REFRESH);
+        when(context.getClient()).thenReturn(client);
+        when(context.getScopeParameter()).thenReturn(scope);
+
+        executor(config).executeOnEvent(context);
+    }
+
+    private OrganizationScopeEnforcerExecutor executor(OrganizationScopeEnforcerExecutorConfiguration config) {
+        KeycloakSession session = mock(KeycloakSession.class, RETURNS_DEEP_STUBS);
+        when(session.getContext()).thenReturn(mock(KeycloakContext.class));
+
+        OrganizationScopeEnforcerExecutor executor = new OrganizationScopeEnforcerExecutor(session);
+        executor.setupConfiguration(config);
+        return executor;
+    }
+
+    private static OrganizationScopeEnforcerExecutorConfiguration defaults() {
+        return new OrganizationScopeEnforcerExecutorConfiguration().parseWithDefaultValues();
+    }
+
+    private static ClientModel organizationAwareClient() {
+        ProtocolMapperModel membershipMapper = new ProtocolMapperModel();
+        membershipMapper.setProtocolMapper(OrganizationMembershipMapper.PROVIDER_ID);
+
+        ClientScopeModel organizationScope = mock(ClientScopeModel.class);
+        when(organizationScope.getName()).thenReturn("organization");
+        when(organizationScope.getProtocolMappersStream()).thenAnswer(invocation -> Stream.of(membershipMapper));
+
+        ClientModel client = mock(ClientModel.class);
+        when(client.getClientScopes(true)).thenReturn(Map.of());
+        when(client.getClientScopes(false)).thenReturn(Map.of("organization", organizationScope));
+        return client;
+    }
+}

--- a/src/test/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeEnforcerIT.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeEnforcerIT.java
@@ -1,0 +1,129 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import de.sventorben.keycloak.kommons.KeycloakDockerContainer;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.OrganizationsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+/**
+ * Exercises the client policy executor against a running Keycloak through the resource owner password credentials
+ * grant, which is the one user bound grant that can be driven without a browser.
+ *
+ * <p>The realm applies the {@code kommons-orgs-scope-enforcer} to every client via an {@code any-client} policy.
+ */
+@Testcontainers
+class OrganizationScopeEnforcerIT {
+
+    private static final String REALM = "OrganizationScopeEnforcerIT";
+
+    @Container
+    private static final KeycloakContainer KEYCLOAK_CONTAINER = KeycloakDockerContainer.create()
+        .withRealmImportFile("OrganizationScopeEnforcerIT-realm.json")
+        .withFeaturesEnabled("organization");
+
+    @BeforeAll
+    static void createOrganizationsAndMembership() {
+        RealmResource realm = KEYCLOAK_CONTAINER.getKeycloakAdminClient().realm(REALM);
+        UserRepresentation user = realm.users().list().stream()
+            .filter(it -> "test".equals(it.getUsername()))
+            .findFirst().orElseThrow(() -> new IllegalStateException("User 'test' not found"));
+
+        OrganizationsResource organizations = realm.organizations();
+        createOrganization(organizations, "org-1", List.of(user));
+        createOrganization(organizations, "org-2", List.of(user));
+    }
+
+    @Test
+    @DisplayName("Given a single named organization, when a token is requested, then it is issued for that organization")
+    void singleNamedOrganizationIsAccepted() throws JWSInputException {
+        AccessToken token = accessTokenFor("openid organization:org-2");
+
+        assertThat(token.getOtherClaims()).containsKey("organization");
+    }
+
+    @Test
+    @DisplayName("Given the bare organization scope, when a token is requested, then the request is accepted")
+    void bareOrganizationScopeIsAccepted() {
+        // Without a browser the user cannot pick, so the token carries no organization claim. What matters here is
+        // that the executor lets the request through.
+        assertThatCode(() -> accessTokenFor("openid organization")).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Given two organization scopes, when a token is requested, then the request is rejected")
+    void severalOrganizationScopesAreRejected() {
+        assertThatThrownBy(() -> accessTokenFor("openid organization:org-1 organization:org-2"))
+            .isInstanceOf(WebApplicationException.class)
+            .satisfies(thrown -> assertThat(status(thrown)).isEqualTo(Response.Status.BAD_REQUEST));
+    }
+
+    @Test
+    @DisplayName("Given all organizations are requested, when a token is requested, then the request is rejected")
+    void allOrganizationsAreRejected() {
+        assertThatThrownBy(() -> accessTokenFor("openid organization:*"))
+            .isInstanceOf(WebApplicationException.class)
+            .satisfies(thrown -> assertThat(status(thrown)).isEqualTo(Response.Status.BAD_REQUEST));
+    }
+
+    @Test
+    @DisplayName("Given no organization scope, when a token is requested, then the request is rejected")
+    void missingOrganizationScopeIsRejected() {
+        assertThatThrownBy(() -> accessTokenFor("openid profile"))
+            .isInstanceOf(WebApplicationException.class)
+            .satisfies(thrown -> assertThat(status(thrown)).isEqualTo(Response.Status.BAD_REQUEST));
+    }
+
+    private static Response.Status status(Throwable thrown) {
+        return Response.Status.fromStatusCode(((WebApplicationException) thrown).getResponse().getStatus());
+    }
+
+    private static AccessToken accessTokenFor(String scope) throws JWSInputException {
+        Keycloak client = Keycloak.getInstance(
+            KEYCLOAK_CONTAINER.getAuthServerUrl(), REALM, "test", "test", "test",
+            null, null, null, false, null, scope);
+
+        String token = client.tokenManager().getAccessToken().getToken();
+        return new JWSInput(token).readJsonContent(AccessToken.class);
+    }
+
+    private static void createOrganization(OrganizationsResource organizations, String name,
+                                           List<UserRepresentation> members) {
+        OrganizationRepresentation organization = new OrganizationRepresentation();
+        organization.setName(name);
+        organization.setEnabled(true);
+
+        OrganizationDomainRepresentation domain = new OrganizationDomainRepresentation();
+        domain.setName(name);
+        organization.addDomain(domain);
+
+        Response response = organizations.create(organization);
+        assumeThat(response.getStatus()).isEqualTo(201);
+
+        String location = response.getHeaderString("Location");
+        String organizationId = location.substring(location.lastIndexOf('/') + 1);
+        members.forEach(member ->
+            assumeThat(organizations.get(organizationId).members().addMember(member.getId()).getStatus())
+                .isEqualTo(201));
+    }
+}

--- a/src/test/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopesTest.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopesTest.java
@@ -1,0 +1,116 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.organization.protocol.mappers.oidc.OrganizationMembershipMapper;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the recognition of organization scopes inside a raw {@code scope} parameter.
+ */
+class OrganizationScopesTest {
+
+    private final ClientModel client = clientWith("organization");
+
+    @Test
+    void recognizesTheBareScopeAsAny() {
+        List<OrganizationScopes.Requested> requested = OrganizationScopes.parse(client, "openid organization profile");
+
+        assertThat(requested).singleElement().satisfies(entry -> {
+            assertThat(entry.rawValue()).isEqualTo("organization");
+            assertThat(entry.scopeName()).isEqualTo("organization");
+            assertThat(entry.kind()).isEqualTo(OrganizationScopes.Kind.ANY);
+        });
+    }
+
+    @Test
+    void recognizesAnAliasAsSpecific() {
+        List<OrganizationScopes.Requested> requested = OrganizationScopes.parse(client, "openid organization:acme");
+
+        assertThat(requested).singleElement().satisfies(entry -> {
+            assertThat(entry.rawValue()).isEqualTo("organization:acme");
+            assertThat(entry.kind()).isEqualTo(OrganizationScopes.Kind.SPECIFIC);
+        });
+    }
+
+    @Test
+    void recognizesTheWildcardAsAll() {
+        List<OrganizationScopes.Requested> requested = OrganizationScopes.parse(client, "organization:*");
+
+        assertThat(requested).singleElement()
+            .extracting(OrganizationScopes.Requested::kind)
+            .isEqualTo(OrganizationScopes.Kind.ALL);
+    }
+
+    @Test
+    void keepsEveryOrganizationScopeSoTheyCanBeCounted() {
+        List<OrganizationScopes.Requested> requested =
+            OrganizationScopes.parse(client, "openid organization:acme organization:globex");
+
+        assertThat(requested).hasSize(2)
+            .extracting(OrganizationScopes.Requested::rawValue)
+            .containsExactly("organization:acme", "organization:globex");
+    }
+
+    @Test
+    void ignoresScopesWithoutTheOrganizationMembershipMapper() {
+        assertThat(OrganizationScopes.parse(client, "openid profile email")).isEmpty();
+        assertThat(OrganizationScopes.parse(client, "organizations organization_unit")).isEmpty();
+    }
+
+    @Test
+    void honoursACustomOrganizationScopeName() {
+        ClientModel renamed = clientWith("tenant");
+
+        assertThat(OrganizationScopes.parse(renamed, "openid tenant:acme")).singleElement()
+            .extracting(OrganizationScopes.Requested::kind)
+            .isEqualTo(OrganizationScopes.Kind.SPECIFIC);
+        assertThat(OrganizationScopes.parse(renamed, "openid organization")).isEmpty();
+    }
+
+    @Test
+    void returnsNothingForAnUnusableInput() {
+        assertThat(OrganizationScopes.parse(null, "organization")).isEmpty();
+        assertThat(OrganizationScopes.parse(client, null)).isEmpty();
+        assertThat(OrganizationScopes.parse(client, "   ")).isEmpty();
+        assertThat(OrganizationScopes.parse(clientWithoutOrganizationScope(), "organization")).isEmpty();
+    }
+
+    private static ClientModel clientWith(String organizationScopeName) {
+        ClientScopeModel organizationScope = mock(ClientScopeModel.class);
+        when(organizationScope.getName()).thenReturn(organizationScopeName);
+        when(organizationScope.getProtocolMappersStream())
+            .thenAnswer(invocation -> Stream.of(protocolMapper(OrganizationMembershipMapper.PROVIDER_ID)));
+
+        ClientModel client = mock(ClientModel.class);
+        when(client.getClientScopes(true)).thenReturn(Map.of());
+        when(client.getClientScopes(false)).thenReturn(Map.of(organizationScopeName, organizationScope));
+        return client;
+    }
+
+    private static ClientModel clientWithoutOrganizationScope() {
+        ClientScopeModel profileScope = mock(ClientScopeModel.class);
+        when(profileScope.getProtocolMappersStream())
+            .thenAnswer(invocation -> Stream.of(protocolMapper("oidc-full-name-mapper")));
+
+        ClientModel client = mock(ClientModel.class);
+        when(client.getClientScopes(true)).thenReturn(Map.of("profile", profileScope));
+        when(client.getClientScopes(false)).thenReturn(Map.of());
+        return client;
+    }
+
+    private static ProtocolMapperModel protocolMapper(String providerId) {
+        ProtocolMapperModel mapper = new ProtocolMapperModel();
+        mapper.setProtocolMapper(providerId);
+        return mapper;
+    }
+}

--- a/src/test/resources/OrganizationScopeEnforcerIT-realm.json
+++ b/src/test/resources/OrganizationScopeEnforcerIT-realm.json
@@ -1,0 +1,2539 @@
+{
+  "id": "139a8cd6-8eda-4a34-bb7c-6757110cdd40",
+  "realm": "OrganizationScopeEnforcerIT",
+  "displayName": "OrganizationScopeEnforcerIT",
+  "displayNameHtml": "",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "bruteForceStrategy": "MULTIPLE",
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "8a79a96f-2c34-4af9-8808-0cc8f002bf61",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "515dcc7b-f535-4f39-ab1d-182247dfa9eb",
+        "attributes": {}
+      },
+      {
+        "id": "dd116038-82af-4fe9-82f3-5f8010652248",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "515dcc7b-f535-4f39-ab1d-182247dfa9eb",
+        "attributes": {}
+      },
+      {
+        "id": "a0dfa618-8c05-4218-a5b0-d4ee860a3dd1",
+        "name": "default-roles-organizationscopeenforcerit",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "view-profile",
+              "manage-account"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "515dcc7b-f535-4f39-ab1d-182247dfa9eb",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "realm-management": [
+        {
+          "id": "a1eca6c2-b614-450a-a882-c816841f72f5",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "5742c167-e928-44c3-beec-39e58167f53b",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "3de2a3ea-ee28-4711-b1dd-0fa0bb3629b4",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "96fedf0c-4dc4-42b3-815b-30d12b174389",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "4ff426d2-a898-4113-aa9e-a7475447b4b4",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "046b19c9-85d3-4596-ae43-777cf31f5916",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "b9267ba6-2789-4e21-b74c-16698f2b5754",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "b2786230-3172-4c48-89e6-f68d96dea069",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "a6185ed9-19f8-4afb-b226-13ed5b81c9ab",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "552a4f58-5cc5-4eb2-b21e-189004290a39",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "52d60fe2-2856-43a8-a67b-901fd2dafda8",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "a2d1f69f-eb5c-4749-ba2e-9833450c7184",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "10950057-83d8-4e40-a45a-a1efa9c64454",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "78d496a1-be6c-4c63-aa54-1dd9ff4ca607",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "017cd887-6089-43c5-8ea5-d6e905a9eb3f",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "b4cd24a3-d3f4-46c0-9235-2e2feb4520ce",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "bc70fb57-f352-4e04-8d90-f62692f6ba83",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-users",
+                "query-groups"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "28296c6e-c58b-44ae-bea0-18d608a36f9e",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-realms",
+                "query-clients",
+                "create-client",
+                "view-realm",
+                "view-clients",
+                "query-users",
+                "manage-clients",
+                "query-groups",
+                "manage-events",
+                "manage-identity-providers",
+                "manage-users",
+                "view-authorization",
+                "view-identity-providers",
+                "view-events",
+                "impersonation",
+                "manage-realm",
+                "view-users",
+                "manage-authorization"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        },
+        {
+          "id": "dfd23af4-9e86-4493-b04c-b9aad3c9f5a2",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06937124-0246-45d5-b4d6-2014de909b47",
+          "attributes": {}
+        }
+      ],
+      "test": [],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "7ca022b8-d99d-4460-ae62-39ceb130437f",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "06e4382b-fffd-4205-8e67-4202ace76504",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "adfd4cdf-1377-4d85-b9eb-12c1f23d55e2",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c8834d8f-2b14-4326-ab4f-8193a43763b7",
+          "attributes": {}
+        },
+        {
+          "id": "97589600-4e25-43ce-a432-96c7f9cc91a7",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c8834d8f-2b14-4326-ab4f-8193a43763b7",
+          "attributes": {}
+        },
+        {
+          "id": "e561a69c-aa12-4254-b4e7-8cb91cae4f61",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "c8834d8f-2b14-4326-ab4f-8193a43763b7",
+          "attributes": {}
+        },
+        {
+          "id": "4567c814-60a1-4659-8ddb-10fb8158c9ce",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c8834d8f-2b14-4326-ab4f-8193a43763b7",
+          "attributes": {}
+        },
+        {
+          "id": "6b5b82d2-c06b-4786-9362-c4c086b627cb",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "c8834d8f-2b14-4326-ab4f-8193a43763b7",
+          "attributes": {}
+        },
+        {
+          "id": "5bffe68e-5a57-4092-8bbc-0d61a5cac55b",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c8834d8f-2b14-4326-ab4f-8193a43763b7",
+          "attributes": {}
+        },
+        {
+          "id": "825fdf03-3aae-4763-ba40-b516b0c837c0",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c8834d8f-2b14-4326-ab4f-8193a43763b7",
+          "attributes": {}
+        },
+        {
+          "id": "09bd60d2-177c-404a-9b7e-86f7ea512e9c",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "c8834d8f-2b14-4326-ab4f-8193a43763b7",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "a0dfa618-8c05-4218-a5b0-d4ee860a3dd1",
+    "name": "default-roles-organizationscopeenforcerit",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "515dcc7b-f535-4f39-ab1d-182247dfa9eb"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "users": [
+    {
+      "id": "ec1175a0-0619-4d33-b1a3-513ad19774b5",
+      "createdTimestamp": 1632070461116,
+      "username": "test",
+      "firstName": "Test",
+      "lastName": "User",
+      "enabled": true,
+      "totp": false,
+      "email": "test@example.com",
+      "emailVerified": true,
+      "credentials": [
+        {
+          "id": "1bb7101e-6029-4195-9597-8951f6a7e785",
+          "type": "password",
+          "createdDate": 1632070469930,
+          "secretData": "{\"value\":\"f0KV+30selJs9QbGBR/Yl62Eu0fRP2EUudbUEYMLgEdeXrRMKZFMtY3OlfG3W9a6ygNflxj9ysUv4j/RwnMN8g==\",\"salt\":\"ZAaXBhufypfX/dSuy9+Pdg==\",\"additionalParameters\":{}}",
+          "credentialData": "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-test-realm"
+      ],
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account",
+          "view-groups"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "c8834d8f-2b14-4326-ab4f-8193a43763b7",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/OrganizationScopeEnforcerIT/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/OrganizationScopeEnforcerIT/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "b2cee109-ece9-420b-90a9-e888fd219a70",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/OrganizationScopeEnforcerIT/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/OrganizationScopeEnforcerIT/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "5eca0d8c-5079-4644-8961-3d3ba107dbab",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "26a8a436-c8ef-4019-a308-bacaca780627",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "06e4382b-fffd-4205-8e67-4202ace76504",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "06937124-0246-45d5-b4d6-2014de909b47",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "6959bc26-2f1e-488e-af72-be751be4074a",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/OrganizationScopeEnforcerIT/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/OrganizationScopeEnforcerIT/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "d7cc2f15-acb4-420f-b138-43a915a42b46",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "13cad241-3a98-4218-b322-8aa6f9466a91",
+      "clientId": "test",
+      "name": "",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "frontchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "display.on.consent.screen": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "organization",
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "4a6145f8-8049-4b3c-8873-05e9fff0f45d",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "2a7981b2-01d6-4370-9afd-2d5ae983eeb1",
+      "name": "organization",
+      "description": "Additional claims about the organization a subject belongs to",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${organizationScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "2d5ee485-195d-4da3-8cd2-4f60e317497e",
+          "name": "organization",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "organization",
+            "jsonType.label": "JSON",
+            "multivalued": "true",
+            "addOrganizationAttributes": "true",
+            "addOrganizationId": false
+          }
+        }
+      ]
+    },
+    {
+      "id": "3aecacac-d26a-4bf8-8794-5874e48ea634",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "${rolesScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "d1bab57b-fd78-4d39-97ee-9a3f8b835319",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "dc9b1bdc-c4d5-413a-b9c3-dfcd5f4f6175",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "e692ca35-73aa-4132-84d5-69abeede4d69",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "283ac489-a956-4a02-ae26-453a30c786b8",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "8469de61-ed8b-4efa-ae2a-df89d0ad61ef",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "54763e26-46de-4631-92d8-d15c3c05b30c",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a61b4628-5d86-44ae-b834-9ed0c3875881",
+      "name": "service_account",
+      "description": "Specific scope for a client enabled for service accounts",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "338e8a06-dd59-4c3d-9137-fdc8f880dbeb",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "795f8520-b116-4ccf-b6bb-7e0dd4f0c0a3",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6154e408-711f-438e-9cb0-3dd563583244",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "f237c376-f524-4ff0-b0fe-29600a0f416a",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "9749a619-705a-47fb-b101-19346586d01b",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "76a8fd5e-4aa1-4888-9a45-4f2763dc6105",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "99a899ac-9ca1-4991-9320-3b5521daafe4",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a9f9fe0d-ddb9-45c9-8c19-1e98ea5e6cba",
+      "name": "saml_organization",
+      "description": "Organization Membership",
+      "protocol": "saml",
+      "attributes": {
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "f0723fd4-9842-49bb-84f0-376a9237130c",
+          "name": "organization",
+          "protocol": "saml",
+          "protocolMapper": "saml-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "f8067878-b72c-4c1a-9bcc-16dc31e9b26c",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${phoneScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "1c866e51-2851-4164-9942-7e50b272afe4",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cf4454b7-2510-4d72-9c7b-2e6171c2a4e0",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "3d2476c1-77e6-4f51-9977-e300780eb5fe",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "da715d14-d78a-437b-84f2-fc619df16103",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "9b084179-4266-4a85-b6eb-febbb3151a23",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${emailScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "9dfbf1b5-006a-48a2-9bc7-94aa6c52f826",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "63d1394c-fbe9-4ed7-8131-74ac1dd60a6a",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "ca2e33a3-3085-4a63-88f7-c7d1bb352816",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${addressScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "5ec9f1d1-1ff1-43c6-a254-a2e635eb7c0d",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "introspection.token.claim": "true",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "0beacde8-64e9-425a-a818-f6d1b7371a5b",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${profileScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "396ff6a4-023f-4bd5-9fa7-504976fac22b",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6bbb69e6-5faa-4805-a3e4-dbab74529e93",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "492f4cf3-dfe6-4f74-b5cc-cbf09e6d39ec",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7457602a-c6e0-4bd5-bc03-5201e74a3b89",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5adfb331-4fb6-4a3b-8ec1-d560511f3466",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "31480444-502d-4a16-be4d-79cd03db631b",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d5f93426-aeb1-436f-8e2e-787f417b2bc8",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "df1f7bd8-6814-4232-9366-b4e2b7fd3789",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3e82f599-8327-4c32-959a-6ffa4ef48249",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d8f658b7-7c0f-4070-a2d7-8612cb0f9ebc",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3ff4291c-d6d3-4035-88eb-413599ccb5d6",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "bce3ee49-a124-48a5-a928-e10ab70a5ab3",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "219f1fe5-9aa0-48cc-ab78-a8374aaff624",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5e327da3-9b07-4639-8f87-a026413db5b7",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "509f54dc-a298-4324-9611-b855e32944ee",
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "92298dca-ecc5-4fff-98a9-182f2107d928",
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "id": "789ddafe-a494-4c15-9f96-4cf330eca20d",
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "saml_organization",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr",
+    "basic"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt",
+    "organization"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "0addae7a-a4a6-48e6-b3d7-bf9a5fbeb1b9",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "988024e1-39e6-492d-80c9-ad88d25abca9",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "9c0ea8d4-0e9f-485b-91ea-d5134231c227",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "fc69eb1b-4642-4162-9782-38b59688b757",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "0e7c2636-279e-44c3-ae86-9b1ab8b713f5",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-full-name-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-address-mapper",
+            "saml-user-property-mapper",
+            "oidc-usermodel-property-mapper",
+            "saml-role-list-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-sha256-pairwise-sub-mapper"
+          ]
+        }
+      },
+      {
+        "id": "92961c9a-1ba4-47ef-a548-2edd210624ca",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "760bf14b-72b9-4a5d-ae70-02ed9f11e935",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-full-name-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-attribute-mapper",
+            "saml-user-property-mapper"
+          ]
+        }
+      },
+      {
+        "id": "fb4a5005-e247-4662-9eb3-64e3f8cd34a5",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "b67ceabc-4e36-4cb9-8dae-d40d8fae7ede",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "f4e52ac7-b39c-415f-966e-269c773d0847",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "RSA-OAEP"
+          ]
+        }
+      },
+      {
+        "id": "5aeb30a9-f122-4fcd-9824-1d066b2b554d",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS512"
+          ]
+        }
+      },
+      {
+        "id": "32bff87e-975c-462c-8556-845a38d5375d",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
+    {
+      "id": "d9d83b02-42c1-409d-9bd4-67bde70ace23",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "669c5fac-d242-46b2-ba50-747fd971c8b6",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0ff7d120-e38e-4547-ac3e-b91a32520b37",
+      "alias": "Browser - Conditional Organization",
+      "description": "Flow to determine if the organization identity-first login is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "organization",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "c85bdc89-1361-4f67-b6c6-be2c83e575e4",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e8960f72-9fb5-4aeb-b126-1346b98aa2bd",
+      "alias": "First Broker Login - Conditional Organization",
+      "description": "Flow to determine if the authenticator that adds organization members is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "idp-add-organization-member",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "d5e36b1d-a77d-47f9-af41-090fb6747dbe",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "663629ed-e7dd-416a-a963-dd7d882210ab",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "98af8a67-c592-43c0-9f42-3f56c33e03d8",
+      "alias": "Organization",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "73013061-35f4-48ed-a01b-ae01d44393bf",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "09292275-bf29-465e-a1b6-33faf42df843",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a99d5a59-0d89-4cb6-9065-93c25f9c2d39",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "1abea37d-97d5-491b-9895-6dc40b11a2c9",
+      "alias": "browser",
+      "description": "Browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 26,
+          "autheticatorFlow": true,
+          "flowAlias": "Organization",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e6926da9-e227-4367-9511-9ad5515adf95",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "278a19e6-d4cb-42ac-9021-f935c5e54415",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "ad365adc-68fc-485a-a344-b3b90a37eda8",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "6f82b400-4a58-4a67-8975-48ccbd6f8000",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 50,
+          "autheticatorFlow": true,
+          "flowAlias": "First Broker Login - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a877d6d6-b086-4b9a-86d9-e87e2db26385",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "88449735-69aa-47f5-b812-65ac5fdf7c1f",
+      "alias": "registration",
+      "description": "Registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e4b30d54-ef6d-4375-87e6-29b806251cec",
+      "alias": "registration form",
+      "description": "Registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "bd2b004a-879c-4a52-aac6-939e8073c0dc",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a0b535e5-6d11-402f-8731-fa085c9abcec",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "75bed3e6-c928-4f6c-8987-ddf28cd8deb8",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "c5a7a0ec-b308-4ccc-906b-0981460d8b04",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 90,
+      "config": {}
+    },
+    {
+      "alias": "delete_credential",
+      "name": "Delete Credential",
+      "providerId": "delete_credential",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 100,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DevicePollingInterval": "5",
+    "clientOfflineSessionMaxLifespan": "0",
+    "clientSessionIdleTimeout": "0",
+    "clientOfflineSessionIdleTimeout": "0",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false",
+    "cibaExpiresIn": "120",
+    "oauth2DeviceCodeLifespan": "600",
+    "saml.signature.algorithm": "",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "0",
+    "frontendUrl": "",
+    "acr.loa.map": "{}"
+  },
+  "keycloakVersion": "26.2.5",
+  "userManagedAccessAllowed": false,
+  "organizationsEnabled": true,
+  "verifiableCredentialsEnabled": false,
+  "adminPermissionsEnabled": false,
+  "clientProfiles": {
+    "profiles": [
+      {
+        "name": "single-organization",
+        "description": "Binds every session to exactly one organization.",
+        "executors": [
+          {
+            "executor": "kommons-orgs-scope-enforcer",
+            "configuration": {
+              "kommons.orgs.require.scope": true,
+              "kommons.orgs.selection.mode": "any-single"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "clientPolicies": {
+    "policies": [
+      {
+        "name": "single-organization-for-all-clients",
+        "description": "Applies the single organization profile to every client.",
+        "enabled": true,
+        "conditions": [
+          {
+            "condition": "any-client",
+            "configuration": {}
+          }
+        ],
+        "profiles": [
+          "single-organization"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #111

Adds three cooperating providers that bind every session to exactly one organization: the user picks at login and cannot skip it, no request can ask for two organizations or for all of them, and none can quietly ask for none.

| Provider | Type | Purpose |
|---|---|---|
| `kommons-orgs-scope-enforcer` | Client policy executor | Rejects requests whose `scope` does not resolve to exactly one organization |
| `kommons-orgs-scope-injector` | Authenticator | Adds the organization scope to OIDC requests that did not ask for it |
| `kommons-orgs-select-organization` | Required action | Makes the user choose for protocols without a `scope` parameter (SAML) |

Not every deployment needs all three — see the "Which pieces do I need?" table in the docs.

## Design notes

**Why an authenticator is needed at all.** Keycloak's login side reads the raw `scope` request parameter (`OrganizationScope.getRequestedScopes`), while the token side reads the granted client scopes (`DefaultClientSessionContext.getScopeString(true)`). Assigning the organization client scope as a *default* scope therefore only reaches the mappers, never the selection. Rewriting the requested scope is the one change both sides observe.

**Why the injector must be `ALTERNATIVE` and sit before `Cookie`.** `CookieAuthenticator` yields to the `Organization` sub-flow only when an organization scope was requested, so the scope has to be in place before it runs. The factory deliberately does not offer `REQUIRED`, because a required execution disables every alternative of its parent flow and would break cookie based SSO. The authenticator only ever reports `attempted` and swallows its own failures, so it can never block a login.

**Why a required action for SAML.** The built-in selection is driven by the organization scope, which SAML does not have. Required actions are evaluated on every authentication regardless of protocol — including a login that reuses an existing SSO session — which makes this the one hook that cannot be bypassed. It is gated to non-OIDC protocols so OIDC users are not prompted twice, and it reuses the base theme's `select-organization.ftl`, so no theme ships with the library.

**Scope recognition.** Organization scopes are recognised by their `oidc-organization-membership-mapper`, not by the literal name `organization` — the same rule Keycloak applies internally — so renamed or multiple organization scopes keep working. Resolution goes through the `ClientModel` from the policy context rather than `session.getContext().getClient()`, which is not set for every client policy event.

**Refresh.** An empty `scope` on a refresh means "reuse what was granted", not "no organization requested", so a normal refresh is never rejected. An explicit scope on a refresh is still checked.

**Out of scope.** The client credentials grant is not enforced: service accounts have no organization membership.

## Testing

- `OrganizationScopesTest` — 7 unit tests for scope recognition, including custom scope names
- `OrganizationScopeEnforcerExecutorTest` — 10 unit tests for the rejection rules
- `OrganizationScopeEnforcerIT` — 5 integration tests driving the rules through the resource owner password credentials grant against Keycloak 26.7.0, with a client policy applied via `any-client`

All green. The branch was also built in a clean worktree to confirm it does not depend on anything uncommitted.

Every Keycloak API used was verified against the 26.7.0 artifacts rather than `main`, including `CookieAuthenticator.isOrganizationContext`, the `OrganizationScope` constants and the client policy context hierarchies.

## Upstream context

[keycloak/keycloak#39298](https://github.com/keycloak/keycloak/issues/39298) requests exactly this behaviour ("provide a configurable authenticator to enforce organization selection"), but its premise — that an unrequested default organization scope behaves as `ALL` — does not hold on 26.7.0. Measured with the scope assigned as default and a user in two organizations:

| Requested scope | `organization` claim |
|---|---|
| `openid` | absent |
| `openid organization` | **HTTP 500** |
| `openid organization:*` | both organizations |

So it behaves as `ANY`, which resolves to nothing for a multi-organization user — the opposite failure from the one the issue describes. The 500 looks like a separate upstream bug: the dedup filter in `TokenManager.getRequestedClientScopes` only skips the parameterized `organization:` form, never the bare `organization` form, so the default scope instance and the resolved decorator both survive. Worth reporting separately; the stack trace was not captured, so treat the mechanism as a hypothesis.

Relatedly, the guard that stops parameterized scopes being assigned as default (`ClientResource.java:440-443`) does not cover the organization scope, because `OIDCLoginProtocolFactory` never calls `setIsParameterizedScope(true)` on it — unlike the `delegation` scope right below it.

## Notes for review

- CONTRIBUTING asks for one feature per PR. This is one capability but three providers; happy to split into three PRs if you prefer.
- Docs are a new page, `docs/single_organization_per_session.md` (`nav_order: 6`). Note `nav_order: 4` is currently used twice on `main`, which is pre-existing and untouched here.
