### PR TITLE
feat(orgs): optionally bind the organization to the SSO session

### DIFF
--- a/docs/single_organization_per_session.md
+++ b/docs/single_organization_per_session.md
@@ -208,6 +208,14 @@ that reuses an existing single sign-on session, which makes this the one hook th
 The chosen organization is written to the `kc.org` client note — the very note Keycloak's browser flow uses. It
 reaches the authenticated client session through Keycloak's regular note transfer, which is protocol independent.
 
+### Configuration
+
+| Option | Key | Type | Default |
+|---|---|---|---|
+| Bind the organization to the SSO session | `kommons.orgs.bind.to.sso.session` | Boolean | `false` |
+
+See [Binding the organization to the SSO session](#-binding-the-organization-to-the-sso-session) below.
+
 ### Setup
 
 **Authentication → Required actions**, then set **Select Organization** to *Enabled*.
@@ -258,20 +266,51 @@ Two things to get right:
 The enforcer is the only piece that rejects anything, and it has no effect on SAML: SAML has no `scope` parameter, so
 there is nothing for it to validate.
 
+To bind the organization to the whole single sign-on session rather than to each client session, all three are
+needed regardless of protocol — the required action holds the switch and records the binding, the injector applies
+it before Keycloak asks. See [Binding the organization to the SSO session](#-binding-the-organization-to-the-sso-session).
+
+---
+
+## 🔗 Binding the organization to the SSO session
+
+By default Keycloak stores the selected organization in a **client** note, so the choice lives on the client session.
+Every token still names exactly one organization, but two clients in one single sign-on session can end up on two
+*different* organizations, and a user who is a member of several is asked again for every new client.
+
+Switching **Bind the organization to the SSO session** on changes that: the first selection is additionally recorded
+on the **user** session, and every later authentication in that session adopts it instead of asking again.
+
+| | Off (default) | On |
+|---|---|---|
+| Scope of a choice | one client session | the whole SSO session |
+| Two clients, one session | may differ | always identical |
+| Repeat prompt per client | yes | no |
+| Switching organization | new authorization request | requires a new session, i.e. a logout |
+
+### How it works
+
+- The **required action** records the selection as a user session note once it has been made, for every protocol. It
+  does this whether the choice came from its own screen (SAML) or from Keycloak's organization authenticator (OIDC).
+- The **injector authenticator** adopts an existing binding at the very start of the browser flow, before Keycloak's
+  organization handling runs, which is what suppresses the repeat prompt.
+- A binding is re-validated on every use. If the organization was deleted, disabled, or the user's membership was
+  revoked, it is discarded and the user selects again.
+
+> ⚠️ **For OpenID Connect this needs the injector authenticator in the browser flow, ahead of the cookie
+> authenticator.** Without it the binding is still enforced — the required action applies it afterwards — but the
+> user is asked first and the answer is discarded, which is confusing. A warning is logged when that happens.
+
+Because the switch lives on the required action, the required action has to be **Enabled** even in an OIDC-only
+setup, where it otherwise does nothing but record and apply the binding.
+
 ---
 
 ## ⚠️ Limitations
 
-**The choice is per client session, not per single sign-on session.** Keycloak stores the selected organization in a
-client note. Two clients in one single sign-on session can therefore end up on two different organizations. Each
-individual token still names exactly one organization, and the user chose deliberately both times, so "one
-organization per token" holds. If your requirement is stricter and means one organization for the whole single
-sign-on session, you need to pin the selection on the user session — note that doing so also removes the ability to
-switch organizations without a full logout.
-
-**Switching organizations means a new authorization request.** Because a new authorization request starts a fresh
-authentication session whose client notes are empty, a user who is a member of several organizations is asked again.
-That is the switching mechanism; no logout is required.
+**Switching organizations requires a logout when the binding is on.** With the binding off, a new authorization
+request re-prompts a multi-organization user, which is the switching mechanism and needs no logout. With it on, the
+whole point is that later requests adopt the recorded organization, so switching means ending the session.
 
 **Disabled organizations may appear on the selection screen.** The reused `select-organization.ftl` lists the user's
 memberships without filtering by enabled state. This matches Keycloak's own behaviour. A disabled organization is

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeInjectorAuthenticator.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationScopeInjectorAuthenticator.java
@@ -6,6 +6,7 @@ import org.keycloak.authentication.Authenticator;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -59,6 +60,8 @@ final class OrganizationScopeInjectorAuthenticator implements Authenticator {
 
         AuthenticationSessionModel authSession = context.getAuthenticationSession();
 
+        applySessionBinding(context, authSession);
+
         if (!OIDCLoginProtocol.LOGIN_PROTOCOL.equals(authSession.getProtocol())) {
             // Only OpenID Connect has a scope parameter. For SAML use the "Select Organization" required action.
             return;
@@ -83,6 +86,31 @@ final class OrganizationScopeInjectorAuthenticator implements Authenticator {
         authSession.setClientNote(OIDCLoginProtocol.SCOPE_PARAM, updatedScope);
 
         LOG.debugf("Injected organization scope '%s' for client %s", scopeName, client.getClientId());
+    }
+
+    /**
+     * Adopts the organization the single sign-on session is already bound to, before Keycloak's organization
+     * handling runs. This is what keeps a bound session from asking the user again for every new client, and it is
+     * why this authenticator has to sit ahead of the cookie authenticator.
+     *
+     * <p>Runs for every protocol, not just OpenID Connect. It is inert unless the binding is switched on, since no
+     * binding is ever recorded then.
+     */
+    private void applySessionBinding(AuthenticationFlowContext context, AuthenticationSessionModel authSession) {
+        if (!OrganizationSessionBinding.isEnabled(context.getRealm())) {
+            return;
+        }
+
+        if (authSession.getClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE) != null) {
+            return;
+        }
+
+        OrganizationModel bound = OrganizationSessionBinding.boundOrganization(
+            context.getSession(), context.getRealm(), context.getUser());
+
+        if (OrganizationSessionBinding.applyTo(authSession, bound)) {
+            LOG.debugf("Adopted organization '%s' from the bound SSO session", bound.getAlias());
+        }
     }
 
     /**

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationSessionBinding.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationSessionBinding.java
@@ -1,0 +1,155 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import org.jboss.logging.Logger;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionConfigModel;
+import org.keycloak.models.RequiredActionProviderModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+/**
+ * Binds a whole single sign-on session to one organization, rather than letting every client session pick its own.
+ *
+ * <p>Keycloak stores the selected organization in the {@code kc.org} <em>client</em> note, so two clients in one
+ * single sign-on session can end up on two different organizations. When this binding is enabled the first selection
+ * is additionally recorded on the <em>user</em> session, and every later authentication in that session adopts it
+ * instead of asking again.
+ *
+ * <p>The switch lives on the {@code kommons-orgs-select-organization} required action so that there is a single
+ * place to configure it, even though the injector authenticator reads it too.
+ */
+final class OrganizationSessionBinding {
+
+    private static final Logger LOG = Logger.getLogger(OrganizationSessionBinding.class);
+
+    static final String CONFIG_BIND_TO_SSO_SESSION = "kommons.orgs.bind.to.sso.session";
+
+    /**
+     * Note on the user session holding the organization the session is bound to. Deliberately distinct from
+     * {@link OrganizationModel#ORGANIZATION_ATTRIBUTE}, which Keycloak manages per client session.
+     */
+    static final String SESSION_NOTE = "kommons.orgs.bound.organization";
+
+    private OrganizationSessionBinding() {
+    }
+
+    /**
+     * Whether sessions should be bound to a single organization. Requires the required action to be both registered
+     * and enabled, since that is where the switch is configured.
+     */
+    static boolean isEnabled(RealmModel realm) {
+        RequiredActionProviderModel provider =
+            realm.getRequiredActionProviderByAlias(SelectOrganizationRequiredActionFactory.PROVIDER_ID);
+
+        if (provider == null || !provider.isEnabled()) {
+            return false;
+        }
+
+        RequiredActionConfigModel config =
+            realm.getRequiredActionConfigByAlias(SelectOrganizationRequiredActionFactory.PROVIDER_ID);
+
+        return config != null
+            && Boolean.parseBoolean(config.getConfigValue(CONFIG_BIND_TO_SSO_SESSION, Boolean.FALSE.toString()));
+    }
+
+    /**
+     * The organization the current single sign-on session is already bound to, or {@code null}.
+     *
+     * <p>Reads the identity cookie rather than the authentication session, because the user session is not attached
+     * yet while the browser flow is still running. On a fresh login there is no identity cookie, which correctly
+     * yields {@code null}.
+     *
+     * @param user the authenticating user, or {@code null} to fall back to the user of the single sign-on session
+     */
+    static OrganizationModel boundOrganization(KeycloakSession session, RealmModel realm, UserModel user) {
+        AuthenticationManager.AuthResult ssoSession =
+            AuthenticationManager.authenticateIdentityCookie(session, realm, true);
+
+        if (ssoSession == null) {
+            return null;
+        }
+
+        UserSessionModel userSession = ssoSession.getSession();
+        if (userSession == null) {
+            return null;
+        }
+
+        return resolve(session, userSession.getNote(SESSION_NOTE), user == null ? ssoSession.getUser() : user);
+    }
+
+    /**
+     * Resolves a recorded organization id, re-validating it: the organization must still exist, still be enabled,
+     * and the user must still be a member. A stale binding therefore falls back to a fresh selection rather than
+     * pinning the session to something the user may no longer have access to.
+     */
+    static OrganizationModel resolve(KeycloakSession session, String organizationId, UserModel user) {
+        if (organizationId == null) {
+            return null;
+        }
+
+        if (user == null) {
+            return null;
+        }
+
+        OrganizationModel organization = session.getProvider(OrganizationProvider.class).getById(organizationId);
+
+        if (!stillHolds(organization, user)) {
+            LOG.debugf("Discarding stale organization binding '%s'", organizationId);
+            return null;
+        }
+
+        return organization;
+    }
+
+    /**
+     * A binding only holds while the organization still exists, is still enabled, and the user is still a member.
+     */
+    private static boolean stillHolds(OrganizationModel organization, UserModel user) {
+        if (organization == null) {
+            return false;
+        }
+        return organization.isEnabled() && organization.isMember(user);
+    }
+
+    /**
+     * Records the organization on the user session. The note is transferred when the authentication session is
+     * attached, which happens after the required actions have run.
+     */
+    static void bind(AuthenticationSessionModel authSession, OrganizationModel organization) {
+        authSession.setUserSessionNote(SESSION_NOTE, organization.getId());
+        LOG.debugf("Bound the SSO session to organization '%s'", organization.getAlias());
+    }
+
+    /**
+     * Applies an existing binding to the current client session, so Keycloak's organization handling and the
+     * protocol mappers see the organization without asking the user again.
+     *
+     * @return {@code true} when a binding was applied
+     */
+    static boolean applyTo(AuthenticationSessionModel authSession, OrganizationModel organization) {
+        if (organization == null) {
+            return false;
+        }
+
+        String current = authSession.getClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE);
+
+        if (organization.getId().equals(current)) {
+            return true;
+        }
+
+        if (current != null) {
+            LOG.warnf("Overriding organization selection '%s' with the organization the SSO session is bound to "
+                + "('%s'). The user was asked to pick although the session is already bound; add the "
+                + "'Organization Scope Injector' authenticator ahead of the cookie authenticator to avoid this.",
+                current, organization.getAlias());
+        }
+
+        authSession.setClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE, organization.getId());
+        return true;
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/SelectOrganizationRequiredAction.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/SelectOrganizationRequiredAction.java
@@ -48,7 +48,33 @@ final class SelectOrganizationRequiredAction implements RequiredActionProvider {
         }
 
         AuthenticationSessionModel authSession = context.getAuthenticationSession();
+        boolean bindToSsoSession = OrganizationSessionBinding.isEnabled(context.getRealm());
 
+        if (bindToSsoSession && adoptBoundOrganization(context, authSession)) {
+            // The session is already bound, so there is nothing left to choose or to record.
+            return;
+        }
+
+        promptWhenNeeded(context, authSession);
+
+        if (bindToSsoSession) {
+            bindSelection(context, authSession);
+        }
+    }
+
+    /**
+     * Applies the organization the single sign-on session is bound to. The injector authenticator normally did this
+     * before Keycloak's organization handling ran; doing it again here also covers protocols and setups where the
+     * injector is not in the flow.
+     */
+    private boolean adoptBoundOrganization(RequiredActionContext context, AuthenticationSessionModel authSession) {
+        OrganizationModel bound = OrganizationSessionBinding.boundOrganization(
+            context.getSession(), context.getRealm(), context.getUser());
+
+        return OrganizationSessionBinding.applyTo(authSession, bound);
+    }
+
+    private void promptWhenNeeded(RequiredActionContext context, AuthenticationSessionModel authSession) {
         if (OIDCLoginProtocol.LOGIN_PROTOCOL.equals(authSession.getProtocol())) {
             // OpenID Connect is covered by Keycloak's own organization authenticator, which drives the selection from
             // the organization scope. Triggering here as well would ask the user twice.
@@ -62,9 +88,23 @@ final class SelectOrganizationRequiredAction implements RequiredActionProvider {
         List<OrganizationModel> organizations = memberships(context);
 
         if (organizations.size() == 1) {
-            select(authSession, organizations.get(0));
+            select(context, authSession, organizations.get(0));
         } else if (organizations.size() > 1) {
             authSession.addRequiredAction(SelectOrganizationRequiredActionFactory.PROVIDER_ID);
+        }
+    }
+
+    /**
+     * Records an organization that was already selected for this client session, so later client sessions in the
+     * same single sign-on session adopt it. Covers the OpenID Connect case, where Keycloak's own authenticator did
+     * the selecting.
+     */
+    private void bindSelection(RequiredActionContext context, AuthenticationSessionModel authSession) {
+        OrganizationModel selected = OrganizationSessionBinding.resolve(context.getSession(),
+            authSession.getClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE), context.getUser());
+
+        if (selected != null) {
+            OrganizationSessionBinding.bind(authSession, selected);
         }
     }
 
@@ -90,13 +130,18 @@ final class SelectOrganizationRequiredAction implements RequiredActionProvider {
             return;
         }
 
-        select(context.getAuthenticationSession(), organization);
+        select(context, context.getAuthenticationSession(), organization);
         context.success();
     }
 
-    private void select(AuthenticationSessionModel authSession, OrganizationModel organization) {
+    private void select(RequiredActionContext context, AuthenticationSessionModel authSession,
+                        OrganizationModel organization) {
         authSession.setClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE, organization.getId());
-        LOG.debugf("Bound the session to organization '%s'", organization.getAlias());
+        LOG.debugf("Selected organization '%s' for this client session", organization.getAlias());
+
+        if (OrganizationSessionBinding.isEnabled(context.getRealm())) {
+            OrganizationSessionBinding.bind(authSession, organization);
+        }
     }
 
     /**

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/SelectOrganizationRequiredActionFactory.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/SelectOrganizationRequiredActionFactory.java
@@ -7,6 +7,9 @@ import org.keycloak.common.Profile;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.List;
 
 public final class SelectOrganizationRequiredActionFactory
     implements RequiredActionFactory, EnvironmentDependentProviderFactory {
@@ -25,6 +28,27 @@ public final class SelectOrganizationRequiredActionFactory
     @Override
     public boolean isOneTimeAction() {
         return false;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        ProviderConfigProperty bindToSsoSession = new ProviderConfigProperty();
+        bindToSsoSession.setName(OrganizationSessionBinding.CONFIG_BIND_TO_SSO_SESSION);
+        bindToSsoSession.setLabel("Bind the organization to the SSO session");
+        bindToSsoSession.setHelpText("If enabled, the first organization a user selects is remembered for the whole "
+            + "single sign-on session and every later client adopts it instead of asking again. Switching then "
+            + "requires a new session, meaning a logout. If disabled, the organization is chosen per client session, "
+            + "so different clients in one session may end up on different organizations. "
+            + "For OpenID Connect this also needs the 'Organization Scope Injector' authenticator in the browser "
+            + "flow, ahead of the cookie authenticator, otherwise users are still asked and the answer is discarded.");
+        bindToSsoSession.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        bindToSsoSession.setDefaultValue(Boolean.FALSE.toString());
+        return List.of(bindToSsoSession);
     }
 
     @Override

--- a/src/test/java/de/sventorben/keycloak/kommons/orgs/OrganizationSessionBindingTest.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/orgs/OrganizationSessionBindingTest.java
@@ -1,0 +1,172 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionConfigModel;
+import org.keycloak.models.RequiredActionProviderModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import java.util.Map;
+
+import static de.sventorben.keycloak.kommons.orgs.OrganizationSessionBinding.CONFIG_BIND_TO_SSO_SESSION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for binding a single sign-on session to one organization.
+ */
+class OrganizationSessionBindingTest {
+
+    private static final String ORGANIZATION_ID = "org-id";
+
+    @Test
+    void bindingIsOffWhenTheRequiredActionIsNotRegistered() {
+        RealmModel realm = mock(RealmModel.class);
+        when(realm.getRequiredActionProviderByAlias(anyString())).thenReturn(null);
+
+        assertThat(OrganizationSessionBinding.isEnabled(realm)).isFalse();
+    }
+
+    @Test
+    void bindingIsOffWhenTheRequiredActionIsDisabled() {
+        RealmModel realm = realmWith(false, Map.of(CONFIG_BIND_TO_SSO_SESSION, "true"));
+
+        assertThat(OrganizationSessionBinding.isEnabled(realm)).isFalse();
+    }
+
+    @Test
+    void bindingIsOffWhenUnconfiguredOrSwitchedOff() {
+        assertThat(OrganizationSessionBinding.isEnabled(realmWith(true, null))).isFalse();
+        assertThat(OrganizationSessionBinding.isEnabled(realmWith(true, Map.of()))).isFalse();
+        assertThat(OrganizationSessionBinding.isEnabled(realmWith(true, Map.of(CONFIG_BIND_TO_SSO_SESSION, "false"))))
+            .isFalse();
+    }
+
+    @Test
+    void bindingIsOnWhenEnabledAndSwitchedOn() {
+        RealmModel realm = realmWith(true, Map.of(CONFIG_BIND_TO_SSO_SESSION, "true"));
+
+        assertThat(OrganizationSessionBinding.isEnabled(realm)).isTrue();
+    }
+
+    @Test
+    void resolvesARecordedOrganization() {
+        UserModel user = mock(UserModel.class);
+        OrganizationModel organization = organization(true, user, true);
+
+        assertThat(OrganizationSessionBinding.resolve(sessionWith(organization), ORGANIZATION_ID, user))
+            .isSameAs(organization);
+    }
+
+    @Test
+    void discardsABindingThatNoLongerHolds() {
+        UserModel user = mock(UserModel.class);
+
+        // No id recorded, or no user to validate against.
+        assertThat(OrganizationSessionBinding.resolve(sessionWith(null), null, user)).isNull();
+        assertThat(OrganizationSessionBinding.resolve(sessionWith(null), ORGANIZATION_ID, null)).isNull();
+        // Organization deleted meanwhile.
+        assertThat(OrganizationSessionBinding.resolve(sessionWith(null), ORGANIZATION_ID, user)).isNull();
+        // Organization disabled meanwhile.
+        assertThat(OrganizationSessionBinding.resolve(sessionWith(organization(false, user, true)),
+            ORGANIZATION_ID, user)).isNull();
+        // Membership revoked meanwhile.
+        assertThat(OrganizationSessionBinding.resolve(sessionWith(organization(true, user, false)),
+            ORGANIZATION_ID, user)).isNull();
+    }
+
+    @Test
+    void recordsTheOrganizationOnTheUserSession() {
+        AuthenticationSessionModel authSession = mock(AuthenticationSessionModel.class);
+        OrganizationModel organization = organization(true, mock(UserModel.class), true);
+
+        OrganizationSessionBinding.bind(authSession, organization);
+
+        verify(authSession).setUserSessionNote(OrganizationSessionBinding.SESSION_NOTE, ORGANIZATION_ID);
+    }
+
+    @Test
+    void appliesABindingToTheClientSession() {
+        AuthenticationSessionModel authSession = mock(AuthenticationSessionModel.class);
+        OrganizationModel organization = organization(true, mock(UserModel.class), true);
+
+        assertThat(OrganizationSessionBinding.applyTo(authSession, organization)).isTrue();
+
+        verify(authSession).setClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE, ORGANIZATION_ID);
+    }
+
+    @Test
+    void doesNothingWithoutABinding() {
+        AuthenticationSessionModel authSession = mock(AuthenticationSessionModel.class);
+
+        assertThat(OrganizationSessionBinding.applyTo(authSession, null)).isFalse();
+
+        verify(authSession, never()).setClientNote(anyString(), anyString());
+    }
+
+    @Test
+    void keepsAnAlreadyMatchingClientSessionUntouched() {
+        AuthenticationSessionModel authSession = mock(AuthenticationSessionModel.class);
+        when(authSession.getClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE)).thenReturn(ORGANIZATION_ID);
+        OrganizationModel organization = organization(true, mock(UserModel.class), true);
+
+        assertThat(OrganizationSessionBinding.applyTo(authSession, organization)).isTrue();
+
+        verify(authSession, never()).setClientNote(anyString(), anyString());
+    }
+
+    @Test
+    void theBindingWinsOverADifferingSelection() {
+        AuthenticationSessionModel authSession = mock(AuthenticationSessionModel.class);
+        when(authSession.getClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE)).thenReturn("another-org-id");
+        OrganizationModel organization = organization(true, mock(UserModel.class), true);
+
+        assertThat(OrganizationSessionBinding.applyTo(authSession, organization)).isTrue();
+
+        verify(authSession).setClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE, ORGANIZATION_ID);
+    }
+
+    private static RealmModel realmWith(boolean requiredActionEnabled, Map<String, String> config) {
+        RequiredActionProviderModel provider = new RequiredActionProviderModel();
+        provider.setEnabled(requiredActionEnabled);
+
+        RealmModel realm = mock(RealmModel.class);
+        when(realm.getRequiredActionProviderByAlias(SelectOrganizationRequiredActionFactory.PROVIDER_ID))
+            .thenReturn(provider);
+
+        RequiredActionConfigModel configModel = null;
+        if (config != null) {
+            configModel = new RequiredActionConfigModel();
+            configModel.setConfig(config);
+        }
+        when(realm.getRequiredActionConfigByAlias(SelectOrganizationRequiredActionFactory.PROVIDER_ID))
+            .thenReturn(configModel);
+
+        return realm;
+    }
+
+    private static OrganizationModel organization(boolean enabled, UserModel member, boolean isMember) {
+        OrganizationModel organization = mock(OrganizationModel.class);
+        when(organization.getId()).thenReturn(ORGANIZATION_ID);
+        when(organization.isEnabled()).thenReturn(enabled);
+        when(organization.isMember(member)).thenReturn(isMember);
+        return organization;
+    }
+
+    private static KeycloakSession sessionWith(OrganizationModel organization) {
+        OrganizationProvider provider = mock(OrganizationProvider.class);
+        when(provider.getById(ORGANIZATION_ID)).thenReturn(organization);
+
+        KeycloakSession session = mock(KeycloakSession.class);
+        when(session.getProvider(OrganizationProvider.class)).thenReturn(provider);
+        return session;
+    }
+}


### PR DESCRIPTION
Closes #113

Adds a **Bind the organization to the SSO session** switch on the `kommons-orgs-select-organization` required action. When enabled, the first organization a user selects is recorded on the **user** session, and every later authentication in that session adopts it instead of asking again.

| | Off (default) | On |
|---|---|---|
| Scope of a choice | one client session | the whole SSO session |
| Two clients, one session | may differ | always identical |
| Repeat prompt per client | yes | no |
| Switching organization | new authorization request | requires a new session, i.e. a logout |

## How it works

- The **required action** records the selection for every protocol, whether it came from its own screen (SAML) or from Keycloak's organization authenticator (OIDC). It runs on every authentication, including one that reuses an existing SSO session.
- The **injector authenticator** adopts an existing binding at the start of the browser flow, *before* Keycloak's organization handling runs. That is what suppresses the repeat prompt, and it is why the injector must sit ahead of the cookie authenticator.
- Without the injector the binding is still enforced afterwards, but the user is asked first and the answer discarded. That case logs a warning naming the fix rather than failing silently.
- A binding is re-validated on every use: organization deleted, disabled, or membership revoked all discard it and fall back to a fresh selection.

Reading the binding goes through the identity cookie rather than the authentication session, because the user session is not attached yet while the browser flow is still running. Recording it uses `setUserSessionNote`, which is transferred when the authentication session is attached — `AuthenticationProcessor` does that *after* required actions have run (`attachSession(); // Session will be attached after requiredActions + consents are finished.`).

The switch lives on the required action so there is a single place to configure it; the injector reads it from there via `realm.getRequiredActionConfigByAlias(...)`. As a result the required action has to be enabled even in an OIDC-only setup, which the docs call out.

## Testing

11 new unit tests in `OrganizationSessionBindingTest`, covering the enablement gate, re-validation of a stale binding, recording, adoption, and that the binding wins over a differing selection. `OrganizationScopeEnforcerIT` still passes.

## Notes for review

- Docs updated in `single_organization_per_session.md`: new section "Binding the organization to the SSO session", plus a rewritten limitations section.
- The remaining limitation is now the deliberate trade-off: with binding on, switching organization requires a logout.
