### PR TITLE
feat(orgs): read Keycloak organization groups in the group mapper

### DIFF
--- a/docs/org_aware_group_mapper.md
+++ b/docs/org_aware_group_mapper.md
@@ -47,7 +47,30 @@ Only groups within the resolved organization are included. Groups from other ten
 To function properly, the mapper expects:
 
 1. The **organization feature** enabled in your Keycloak instance
-2. A group hierarchy like this:
+2. Groups organized in one of the two layouts described below
+
+---
+
+## 📚 Where groups come from
+
+Keycloak did not always have organization groups. This mapper therefore understands **two layouts**.
+
+### Organization groups (native)
+
+Groups created under an organization, which Keycloak stores as groups of type `ORGANIZATION`. They can be
+**nested**:
+
+```
+acme (organization)
+├── sales
+└── engineering
+    └── leads
+```
+
+### The group tree convention (legacy)
+
+A realm group named `organizations` holding one subgroup per organization alias, whose direct children are that
+organization's groups. This is what the mapper supported before Keycloak had organization groups:
 
 ```
 organizations/
@@ -57,6 +80,45 @@ organizations/
 ├── globex/
 │   ├── users
 ```
+
+Only the **direct children** of the alias group are read, so this layout is flat by construction.
+
+### 🔧 Setting
+
+| Field | Value |
+|---|---|
+| **Option** | `Where to read groups from` |
+| **Property Key** | `kommons.orgs.group.source` |
+| **Type** | `auto` \| `organization-groups` \| `convention` |
+| **Default** | `auto` |
+
+`auto` uses organization groups when the organization has any, and otherwise falls back to the convention tree. It
+is resolved **per organization**, so a realm can be migrated one organization at a time — during the migration a
+single token may well carry native groups for one organization and convention groups for another.
+
+An organization that is not represented in the selected layout contributes no claim at all, which is different from
+being represented but having no groups for this user (that yields an empty list).
+
+---
+
+## 🏷️ How a group is rendered
+
+| Field | Value |
+|---|---|
+| **Option** | `How to render a group` |
+| **Property Key** | `kommons.orgs.group.label` |
+| **Type** | `name` \| `path` |
+| **Default** | `name` |
+
+- **`name`** — the group's own name, e.g. `leads`. This is what the mapper has always emitted.
+- **`path`** — the group's path *within its organization*, e.g. `engineering/leads`.
+
+The path is relative to the organization, never absolute: Keycloak roots each organization's hierarchy in an
+internal group named after the organization's **ID**, and that segment is stripped. You will never see a UUID in the
+claim.
+
+Since the convention layout is flat, `path` and `name` produce identical output for it. The setting only makes a
+difference for nested organization groups.
 
 ### ⚠️ Recommended Configuration: Organization Membership Mapper
 
@@ -204,9 +266,44 @@ You should consider enabling this option if:
 
 ---
 
+### 🔣 Choosing the separator
+
+| Field | Value |
+|---|---|
+| **Option** | `Separator between organization alias and group` |
+| **Property Key** | `kommons.orgs.prefix.separator` |
+| **Type** | String |
+| **Default** | `_` |
+
+The default underscore is what this mapper has always used, but it is a poor delimiter whenever aliases or group
+names may contain one themselves:
+
+```
+acme_dev_leads
+```
+
+A consumer splitting that value cannot tell whether the organization is `acme` and the group `dev_leads`, or the
+organization is `acme_dev` and the group `leads`. If anything downstream parses the value back apart, pick a
+separator that cannot occur in either part:
+
+| Separator | Result |
+|---|---|
+| `_` (default) | `acme_engineering/leads` |
+| `:` | `acme:engineering/leads` |
+| `::` | `acme::engineering/leads` |
+| `/` | `acme/engineering/leads` |
+
+An empty value falls back to `_`, because the Admin Console cannot distinguish "unset" from "deliberately empty"
+and silently producing `acmeleads` would be worse than doing nothing.
+
+The separator only applies when prefixing is enabled, and only once at the front of the label — it never replaces
+the `/` inside a `path` label.
+
+---
+
 ### 📝 Notes
 
-- The underscore `_` is used as the delimiter: `orgalias_groupname`
+- The separator defaults to an underscore `_`: `orgalias_groupname`
 - The prefix only applies to group names listed in the token — it does **not** affect group names or structures inside Keycloak
 - Token consumers must be prepared to handle the prefixed format if this is enabled
 
@@ -283,6 +380,67 @@ Enable this if:
 
 ---
 
+
+## 🧮 The full matrix
+
+`label`, `prefix` and `flatten` compose freely. For a user in organization `acme` who is a member of the top level
+group `sales` and the nested group `engineering/leads`:
+
+| label | prefix | flatten | Claim |
+|---|---|---|---|
+| `name` | off | off | `"organization": { "acme": { "groups": ["sales", "leads"] } }` |
+| `name` | off | on | `"groups": ["sales", "leads"]` |
+| `name` | on | off | `"organization": { "acme": { "groups": ["acme_sales", "acme_leads"] } }` |
+| `name` | on | on | `"groups": ["acme_sales", "acme_leads"]` |
+| `path` | off | off | `"organization": { "acme": { "groups": ["sales", "engineering/leads"] } }` |
+| `path` | off | on | `"groups": ["sales", "engineering/leads"]` |
+| `path` | on | off | `"organization": { "acme": { "groups": ["acme_sales", "acme_engineering/leads"] } }` |
+| `path` | on | on | `"groups": ["acme_sales", "acme_engineering/leads"]` |
+
+The prefix is applied **once, at the front of the whole label** — `acme_engineering/leads`, not
+`acme_engineering/acme_leads`.
+
+Prefixing matters most when flattening: without it, two organizations that both have a `leads` group become
+indistinguishable once merged into one flat array. With `path` labels the risk is smaller but not gone, since
+`engineering/leads` can exist in several organizations too.
+
+---
+
+## 🤝 Using it with Single Organization per Session
+
+This mapper pairs naturally with [Single Organization per Session]({{ site.baseurl }}/single_organization_per_session.html),
+and the combination is the one most deployments actually want.
+
+**Why they fit together.** This mapper emits groups for *every organization it resolves*. If a client requests
+`organization:*`, that is every organization the user belongs to, and a flattened claim then mixes groups from all
+of them into one array. Single Organization per Session guarantees the request resolves to **exactly one**
+organization, which makes the group claim unambiguous.
+
+**What that buys you:**
+
+- With the enforcer rejecting `organization:*` and multiple organization scopes, `groups` can only ever describe one
+  organization.
+- With **flatten on**, you get a plain top-level `groups` array — the shape most applications and API gateways
+  expect — and it is safe, because only one organization can contribute to it.
+- **Prefixing becomes optional** rather than a necessity. It is still worth enabling if your downstream systems
+  compare group names across sessions and you want the tenant visible in the value itself.
+
+**Recommended combination for a single-tenant-per-session setup:**
+
+| Setting | Value |
+|---|---|
+| Single Organization per Session | enabled (enforcer, plus injector for OIDC clients you cannot change) |
+| `kommons.emit.flattened.group.claim` | `true` |
+| `kommons.prefix.groups.with.organization` | `false`, unless you want the tenant in every value |
+| `kommons.orgs.group.label` | `path` if your groups are nested, otherwise `name` |
+| `kommons.orgs.group.source` | `auto` |
+
+**One shared mechanism worth knowing.** Both features read the same `kc.org` client session note. When the user
+selects an organization — or when a session is bound to one — this mapper resolves that organization directly from
+the note rather than from the requested scope. So the organization the user picked at login is exactly the one whose
+groups end up in the token, including on single sign-on where no selection screen was shown.
+
+---
 
 ## 🧩 Scope Resolution Logic
 

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/OidcOrgsGroupMapperFactory.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/OidcOrgsGroupMapperFactory.java
@@ -32,10 +32,12 @@ public final class OidcOrgsGroupMapperFactory extends AbstractOIDCProtocolMapper
 
     private static final String PROVIDER_ID = "kommons-orgs-group-mapper";
 
-    private static final String ROOT_GROUP_NAME = "organizations";
 
     private static final String CONFIG_PREFIX_GROUPS = "kommons.prefix.groups.with.organization";
     private static final String CONFIG_FLAT_GROUPS = "kommons.emit.flattened.group.claim";
+    private static final String CONFIG_GROUP_SOURCE = "kommons.orgs.group.source";
+    private static final String CONFIG_GROUP_LABEL = "kommons.orgs.group.label";
+    private static final String CONFIG_PREFIX_SEPARATOR = "kommons.orgs.prefix.separator";
 
     private static final String CLAIM_ORGANIZATION = "organization";
     private static final String CLAIM_GROUPS = "groups";
@@ -72,16 +74,59 @@ public final class OidcOrgsGroupMapperFactory extends AbstractOIDCProtocolMapper
         prefixGroupsProp.setRequired(true);
         properties.add(prefixGroupsProp);
 
+        ProviderConfigProperty prefixSeparatorProp = new ProviderConfigProperty();
+        prefixSeparatorProp.setName(CONFIG_PREFIX_SEPARATOR);
+        prefixSeparatorProp.setLabel("Separator between organization alias and group");
+        prefixSeparatorProp.setHelpText("Used only when prefixing is enabled. Defaults to '"
+            + OrganizationGroups.DEFAULT_PREFIX_SEPARATOR + "'. Pick something that cannot occur in an alias or a "
+            + "group name, for example ':' or '::', if consumers need to split the value back apart. Group names "
+            + "containing the separator make 'acme" + OrganizationGroups.DEFAULT_PREFIX_SEPARATOR
+            + "dev" + OrganizationGroups.DEFAULT_PREFIX_SEPARATOR + "leads' ambiguous.");
+        prefixSeparatorProp.setType(ProviderConfigProperty.STRING_TYPE);
+        prefixSeparatorProp.setDefaultValue(OrganizationGroups.DEFAULT_PREFIX_SEPARATOR);
+        prefixSeparatorProp.setRequired(false);
+        properties.add(prefixSeparatorProp);
+
         ProviderConfigProperty flatGroupsProp = new ProviderConfigProperty();
         flatGroupsProp.setName(CONFIG_FLAT_GROUPS);
         flatGroupsProp.setLabel("Emit flattened group claim");
         flatGroupsProp.setHelpText("Places all group names into a top-level 'groups' claim instead of nesting them by organization.");
         flatGroupsProp.setType(ProviderConfigProperty.BOOLEAN_TYPE);
         flatGroupsProp.setDefaultValue("false");
-        prefixGroupsProp.setRequired(true);
+        flatGroupsProp.setRequired(true);
         properties.add(flatGroupsProp);
 
+        ProviderConfigProperty groupSourceProp = new ProviderConfigProperty();
+        groupSourceProp.setName(CONFIG_GROUP_SOURCE);
+        groupSourceProp.setLabel("Where to read groups from");
+        groupSourceProp.setHelpText("'auto': use Keycloak's organization groups when the organization has any, "
+            + "otherwise fall back to the '" + OrganizationGroups.CONVENTION_ROOT_GROUP + "' group tree. "
+            + "'organization-groups': only Keycloak's organization groups. "
+            + "'convention': only the '" + OrganizationGroups.CONVENTION_ROOT_GROUP + "' group tree. "
+            + "'auto' is resolved per organization, so a realm can be migrated one organization at a time.");
+        groupSourceProp.setType(ProviderConfigProperty.LIST_TYPE);
+        groupSourceProp.setOptions(List.of("auto", "organization-groups", "convention"));
+        groupSourceProp.setDefaultValue("auto");
+        groupSourceProp.setRequired(true);
+        properties.add(groupSourceProp);
+
+        ProviderConfigProperty groupLabelProp = new ProviderConfigProperty();
+        groupLabelProp.setName(CONFIG_GROUP_LABEL);
+        groupLabelProp.setLabel("How to render a group");
+        groupLabelProp.setHelpText("'name': the name of the group itself, for example 'leads'. "
+            + "'path': the path of the group within its organization, for example 'engineering/leads'. "
+            + "Only organization groups can be nested, so for the group tree convention both are the same.");
+        groupLabelProp.setType(ProviderConfigProperty.LIST_TYPE);
+        groupLabelProp.setOptions(List.of("name", "path"));
+        groupLabelProp.setDefaultValue("name");
+        groupLabelProp.setRequired(true);
+        properties.add(groupLabelProp);
+
         return properties;
+    }
+
+    private String getConfig(ProtocolMapperModel model, String key) {
+        return model.getConfig() == null ? null : model.getConfig().get(key);
     }
 
     @Override
@@ -117,26 +162,17 @@ public final class OidcOrgsGroupMapperFactory extends AbstractOIDCProtocolMapper
             .orElse(CLAIM_ORGANIZATION);
 
 
-        final GroupModel organizations = keycloakSession.groups().getGroupByName(realm, null, ROOT_GROUP_NAME);
-        if (organizations == null) {
-            ClientModel client = clientSessionCtx.getClientSession().getClient();
-            LOG.warnf("Root group `%s` does not exist but mapper configured in realm %s, client %", ROOT_GROUP_NAME, client.getRealm().getName(), client.getName());
-            return;
-        }
-
         String orgId = clientSessionCtx.getClientSession().getNote(OrganizationModel.ORGANIZATION_ATTRIBUTE);
-        Stream<OrganizationModel> requestedOrganizations;
-        requestedOrganizations = resolveRequestedOrganizations(userSession, keycloakSession, clientSessionCtx, orgId);
+        List<OrganizationModel> requestedOrganizations =
+            resolveRequestedOrganizations(userSession, keycloakSession, clientSessionCtx, orgId)
+                .filter(Objects::nonNull)
+                .toList();
 
-        final List<String> requestedOrganizationAliases = requestedOrganizations.map(OrganizationModel::getAlias).toList();
-
-        List<GroupModel> orgGroups = organizations.getSubGroupsStream()
-            .filter(tenantRootGroup -> requestedOrganizationAliases.contains(tenantRootGroup.getName())).toList();
         ObjectNode organizationClaims = new ObjectMapper().createObjectNode();
         if (token.getOtherClaims().containsKey(claimName)) {
             Object existingClaim = token.getOtherClaims().get(claimName);
             if (existingClaim != null && !((JsonNode) existingClaim).isObject()) {
-                // TODO: log warning and return
+                LOG.warnf("Claim '%s' is not an object, not adding organization groups to it", claimName);
                 return;
             }
             organizationClaims = (ObjectNode) existingClaim;
@@ -144,28 +180,34 @@ public final class OidcOrgsGroupMapperFactory extends AbstractOIDCProtocolMapper
             token.setOtherClaims(claimName, organizationClaims);
         }
 
-        boolean prefixGroupNames = isPrefixGroups(mappingModel);
         boolean flatGroupClaim = isFlatGroups(mappingModel);
+        OrganizationGroups.Rendering rendering = new OrganizationGroups.Rendering(
+            OrganizationGroups.Source.from(getConfig(mappingModel, CONFIG_GROUP_SOURCE)),
+            OrganizationGroups.Label.from(getConfig(mappingModel, CONFIG_GROUP_LABEL)),
+            OrganizationGroups.AliasPrefix.of(isPrefixGroups(mappingModel),
+                getConfig(mappingModel, CONFIG_PREFIX_SEPARATOR)));
 
         ArrayNode flatGroups = new ObjectMapper().createArrayNode();
 
-        for (GroupModel orgGroup : orgGroups) {
-            String orgAlias = orgGroup.getName();
+        for (OrganizationModel organization : requestedOrganizations) {
+            List<String> groupLabels = OrganizationGroups.labelsFor(
+                keycloakSession, organization, userSession.getUser(), rendering);
 
-            List<String> userGroupNames = orgGroup.getSubGroupsStream()
-                .filter(group -> userSession.getUser().isMemberOf(group))
-                .map(group -> prefixGroupNames ? orgAlias + "_" + group.getName() : group.getName())
-                .toList();
+            if (groupLabels == null) {
+                // The organization is not represented in the selected layout at all.
+                continue;
+            }
 
             if (flatGroupClaim) {
-                userGroupNames.forEach(flatGroups::add);
+                groupLabels.forEach(flatGroups::add);
             } else {
+                String orgAlias = organization.getAlias();
                 ObjectNode orgClaims = organizationClaims.has(orgAlias)
                     ? (ObjectNode) organizationClaims.get(orgAlias)
                     : new ObjectMapper().createObjectNode();
 
                 ArrayNode groupsForOrg = new ObjectMapper().createArrayNode();
-                userGroupNames.stream().map(TextNode::new).forEach(groupsForOrg::add);
+                groupLabels.stream().map(TextNode::new).forEach(groupsForOrg::add);
                 orgClaims.set(CLAIM_GROUPS, groupsForOrg);
 
                 if (!organizationClaims.has(orgAlias)) {

--- a/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationGroups.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/orgs/OrganizationGroups.java
@@ -1,0 +1,215 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import org.jboss.logging.Logger;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.organization.OrganizationProvider;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Collects the groups a user has within an organization and turns them into the labels that end up in the token.
+ *
+ * <p>Two layouts are supported. Keycloak's own <em>organization groups</em>
+ * ({@link org.keycloak.models.GroupModel.Type#ORGANIZATION}) are the native mechanism and can be nested. The
+ * <em>convention</em> layout predates them: a realm group named {@value #CONVENTION_ROOT_GROUP} holding one subgroup
+ * per organization alias, whose direct children are the organization's groups.
+ */
+final class OrganizationGroups {
+
+    private static final Logger LOG = Logger.getLogger(OrganizationGroups.class);
+
+    /** Name of the realm group holding one subgroup per organization alias in the convention layout. */
+    static final String CONVENTION_ROOT_GROUP = "organizations";
+
+    /** Kept as the default so existing tokens do not change shape. */
+    static final String DEFAULT_PREFIX_SEPARATOR = "_";
+
+    private OrganizationGroups() {
+    }
+
+    /**
+     * Where the groups of an organization are read from.
+     */
+    enum Source {
+
+        /** Organization groups when the organization has any, otherwise the convention layout. */
+        AUTO,
+
+        /** Keycloak's organization groups only. */
+        ORGANIZATION_GROUPS,
+
+        /** The {@value #CONVENTION_ROOT_GROUP} group tree only. */
+        CONVENTION;
+
+        static Source from(String value) {
+            return parse(Source.class, value, AUTO);
+        }
+    }
+
+    /**
+     * How a single group is rendered.
+     */
+    enum Label {
+
+        /** The name of the group itself, for example {@code leads}. */
+        NAME,
+
+        /**
+         * The path of the group within its organization, for example {@code engineering/leads}.
+         *
+         * <p>Only organization groups can be nested, so for the convention layout this is the same as
+         * {@link #NAME}.
+         */
+        PATH;
+
+        static Label from(String value) {
+            return parse(Label.class, value, NAME);
+        }
+    }
+
+    private static <E extends Enum<E>> E parse(Class<E> type, String value, E fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        try {
+            return Enum.valueOf(type, value.trim().toUpperCase(Locale.ROOT).replace('-', '_'));
+        } catch (IllegalArgumentException e) {
+            LOG.warnf("Unknown %s '%s', falling back to '%s'", type.getSimpleName(), value, fallback);
+            return fallback;
+        }
+    }
+
+    /**
+     * The labels to emit for {@code organization}.
+     *
+     * @return the labels, or {@code null} when the organization is not represented in the selected layout at all,
+     *         which is different from being represented but having no groups for this user
+     */
+    static List<String> labelsFor(KeycloakSession session, OrganizationModel organization, UserModel user,
+                                  Rendering rendering) {
+        if (organization == null || user == null) {
+            return null;
+        }
+
+        List<String> labels = switch (effectiveSource(session, organization, rendering.source())) {
+            case ORGANIZATION_GROUPS -> organizationGroupLabels(session, organization, user, rendering.label());
+            case CONVENTION -> conventionGroupLabels(session, organization, user);
+            case AUTO -> null; // resolved away by effectiveSource
+        };
+
+        if (labels == null) {
+            return null;
+        }
+
+        return labels.stream()
+            .map(value -> rendering.prefix().apply(value, organization.getAlias()))
+            .toList();
+    }
+
+    /**
+     * How the groups of an organization should be rendered into claim values.
+     *
+     * @param source where the groups are read from
+     * @param label  how a single group is rendered
+     * @param prefix how a label is namespaced with the organization alias
+     */
+    record Rendering(Source source, Label label, AliasPrefix prefix) {
+    }
+
+    /**
+     * Namespacing of a label with the organization alias, so that identically named groups of different
+     * organizations stay distinguishable once they are flattened into a single claim.
+     *
+     * @param enabled   whether to prefix at all
+     * @param separator what to put between alias and label; blank means {@value #DEFAULT_PREFIX_SEPARATOR}. Pick
+     *                  something that cannot occur in an alias or a group name if consumers split the value again.
+     */
+    record AliasPrefix(boolean enabled, String separator) {
+
+        static final AliasPrefix NONE = new AliasPrefix(false, null);
+
+        static AliasPrefix of(boolean enabled, String separator) {
+            return enabled ? new AliasPrefix(true, separator) : NONE;
+        }
+
+        String apply(String label, String alias) {
+            return enabled ? alias + effectiveSeparator() + label : label;
+        }
+
+        private String effectiveSeparator() {
+            return separator == null || separator.isBlank() ? DEFAULT_PREFIX_SEPARATOR : separator;
+        }
+    }
+
+
+    /**
+     * Resolves {@link Source#AUTO} per organization, so a realm can migrate one organization at a time.
+     */
+    private static Source effectiveSource(KeycloakSession session, OrganizationModel organization, Source source) {
+        if (source != Source.AUTO) {
+            return source;
+        }
+
+        boolean hasOrganizationGroups = session.getProvider(OrganizationProvider.class)
+            .getTopLevelGroups(organization, 0, 1)
+            .findAny()
+            .isPresent();
+
+        return hasOrganizationGroups ? Source.ORGANIZATION_GROUPS : Source.CONVENTION;
+    }
+
+    private static List<String> organizationGroupLabels(KeycloakSession session, OrganizationModel organization,
+                                                        UserModel user, Label label) {
+        return session.getProvider(OrganizationProvider.class)
+            .getOrganizationGroupsByMember(organization, user)
+            .map(group -> Label.PATH == label ? organizationGroupPath(group) : group.getName())
+            .toList();
+    }
+
+    /**
+     * The path of an organization group relative to its organization.
+     *
+     * <p>Keycloak's own path builder already stops at the internal group that roots an organization's hierarchy, so
+     * only the leading separator has to go.
+     */
+    private static String organizationGroupPath(GroupModel group) {
+        String path = ModelToRepresentation.buildGroupPath(group);
+        return path.startsWith("/") ? path.substring(1) : path;
+    }
+
+    /**
+     * Groups below {@code /organizations/<alias>}. Returns {@code null} when the organization has no such group,
+     * mirroring what this mapper has always done: an organization missing from the tree contributes no claim at all.
+     */
+    private static List<String> conventionGroupLabels(KeycloakSession session, OrganizationModel organization,
+                                                      UserModel user) {
+        RealmModel realm = session.getContext().getRealm();
+        GroupModel root = session.groups().getGroupByName(realm, null, CONVENTION_ROOT_GROUP);
+
+        if (root == null) {
+            LOG.debugf("Root group '%s' does not exist, no convention groups for organization '%s'",
+                CONVENTION_ROOT_GROUP, organization.getAlias());
+            return null;
+        }
+
+        GroupModel organizationGroup = root.getSubGroupsStream()
+            .filter(group -> organization.getAlias().equals(group.getName()))
+            .findFirst()
+            .orElse(null);
+
+        if (organizationGroup == null) {
+            return null;
+        }
+
+        return organizationGroup.getSubGroupsStream()
+            .filter(user::isMemberOf)
+            .map(GroupModel::getName)
+            .toList();
+    }
+}

--- a/src/test/java/de/sventorben/keycloak/kommons/orgs/OrganizationGroupsMapperIT.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/orgs/OrganizationGroupsMapperIT.java
@@ -1,0 +1,205 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import de.sventorben.keycloak.kommons.KeycloakDockerContainer;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.ClientScopesResource;
+import org.keycloak.admin.client.resource.OrganizationGroupsResource;
+import org.keycloak.admin.client.resource.OrganizationsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+/**
+ * Exercises the mapper against Keycloak's own organization groups, covering the
+ * {@code label} x {@code prefix} x {@code flatten} matrix end to end.
+ *
+ * <p>The realm deliberately contains no {@code organizations} group tree, so the default {@code auto} source has to
+ * resolve to organization groups.
+ *
+ * <p>The organization {@code acme} gets a top level group {@code sales} and a nested group
+ * {@code engineering/leads}; the user is a direct member of both.
+ */
+@Testcontainers
+class OrganizationGroupsMapperIT {
+
+    private static final String REALM = "OrganizationGroupsMapperIT";
+    private static final String MAPPER_NAME = "org-groups";
+
+    private static final String CONFIG_PREFIX_GROUPS = "kommons.prefix.groups.with.organization";
+    private static final String CONFIG_FLAT_GROUPS = "kommons.emit.flattened.group.claim";
+    private static final String CONFIG_GROUP_SOURCE = "kommons.orgs.group.source";
+    private static final String CONFIG_GROUP_LABEL = "kommons.orgs.group.label";
+    private static final String CONFIG_PREFIX_SEPARATOR = "kommons.orgs.prefix.separator";
+
+    @Container
+    private static final KeycloakContainer KEYCLOAK_CONTAINER = KeycloakDockerContainer.create()
+        .withRealmImportFile("OrganizationGroupsMapperIT-realm.json")
+        .withFeaturesEnabled("organization");
+
+    @BeforeAll
+    static void createOrganizationWithGroups() {
+        RealmResource realm = KEYCLOAK_CONTAINER.getKeycloakAdminClient().realm(REALM);
+        UserRepresentation user = realm.users().list().stream()
+            .filter(it -> "test".equals(it.getUsername()))
+            .findFirst().orElseThrow(() -> new IllegalStateException("User 'test' not found"));
+
+        OrganizationsResource organizations = realm.organizations();
+        String organizationId = createOrganization(organizations, "acme");
+        assumeThat(organizations.get(organizationId).members().addMember(user.getId()).getStatus()).isEqualTo(201);
+
+        OrganizationGroupsResource groups = organizations.get(organizationId).groups();
+
+        String salesId = createTopLevelGroup(groups, "sales");
+        String engineeringId = createTopLevelGroup(groups, "engineering");
+        String leadsId = createSubGroup(groups, engineeringId, "leads");
+
+        // Direct membership in a top level and in a nested group.
+        groups.group(salesId).addMember(user.getId());
+        groups.group(leadsId).addMember(user.getId());
+    }
+
+    @Test
+    @DisplayName("label=name, prefix=off, flatten=off")
+    void namesNestedPerOrganization() throws JWSInputException {
+        configure(new MapperConfig("name", false, false, null));
+
+        assertThat(groupsOfOrganization("acme")).containsExactlyInAnyOrder("sales", "leads");
+    }
+
+    @Test
+    @DisplayName("label=name, prefix=on, flatten=on")
+    void prefixedNamesFlattened() throws JWSInputException {
+        configure(new MapperConfig("name", true, true, null));
+
+        assertThat(flatGroups()).containsExactlyInAnyOrder("acme_sales", "acme_leads");
+    }
+
+    @Test
+    @DisplayName("label=path, prefix=off, flatten=on")
+    void pathsFlattened() throws JWSInputException {
+        configure(new MapperConfig("path", false, true, null));
+
+        assertThat(flatGroups()).containsExactlyInAnyOrder("sales", "engineering/leads");
+    }
+
+    @Test
+    @DisplayName("label=path, prefix=on, flatten=on, separator=::")
+    void prefixedPathsWithCustomSeparator() throws JWSInputException {
+        configure(new MapperConfig("path", true, true, "::"));
+
+        assertThat(flatGroups()).containsExactlyInAnyOrder("acme::sales", "acme::engineering/leads");
+    }
+
+    @Test
+    @DisplayName("label=path, prefix=off, flatten=off")
+    void pathsNestedPerOrganization() throws JWSInputException {
+        configure(new MapperConfig("path", false, false, null));
+
+        assertThat(groupsOfOrganization("acme")).containsExactlyInAnyOrder("sales", "engineering/leads");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> flatGroups() throws JWSInputException {
+        Object claim = accessToken().getOtherClaims().get("groups");
+        assertThat(claim).isInstanceOf(List.class);
+        return (List<String>) claim;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> groupsOfOrganization(String alias) throws JWSInputException {
+        Object claim = accessToken().getOtherClaims().get("organization");
+        assertThat(claim).isInstanceOf(Map.class);
+        Map<String, Map<String, List<String>>> organizations = (Map<String, Map<String, List<String>>>) claim;
+        assertThat(organizations).containsKey(alias);
+        return organizations.get(alias).get("groups");
+    }
+
+    private static AccessToken accessToken() throws JWSInputException {
+        Keycloak client = Keycloak.getInstance(
+            KEYCLOAK_CONTAINER.getAuthServerUrl(), REALM, "test", "test", "test",
+            null, null, null, false, null, "openid organization:acme");
+
+        return new JWSInput(client.tokenManager().getAccessToken().getToken()).readJsonContent(AccessToken.class);
+    }
+
+    /** The mapper settings under test, so the combinations stay readable at the call sites. */
+    private record MapperConfig(String label, boolean prefix, boolean flatten, String separator) {
+    }
+
+    private static void configure(MapperConfig config) {
+        ClientScopesResource clientScopes = KEYCLOAK_CONTAINER.getKeycloakAdminClient().realm(REALM).clientScopes();
+
+        ClientScopeRepresentation organizationScope = clientScopes.findAll().stream()
+            .filter(it -> "organization".equals(it.getName()))
+            .findFirst().orElseThrow(() -> new IllegalStateException("organization client scope not found"));
+
+        ProtocolMapperRepresentation mapper = organizationScope.getProtocolMappers().stream()
+            .filter(it -> MAPPER_NAME.equals(it.getName()))
+            .findFirst().orElseThrow(() -> new IllegalStateException(MAPPER_NAME + " protocol mapper not found"));
+
+        mapper.getConfig().put(CONFIG_GROUP_SOURCE, "auto");
+        mapper.getConfig().put(CONFIG_GROUP_LABEL, config.label());
+        mapper.getConfig().put(CONFIG_PREFIX_GROUPS, Boolean.toString(config.prefix()));
+        mapper.getConfig().put(CONFIG_FLAT_GROUPS, Boolean.toString(config.flatten()));
+        if (config.separator() != null) {
+            mapper.getConfig().put(CONFIG_PREFIX_SEPARATOR, config.separator());
+        } else {
+            mapper.getConfig().remove(CONFIG_PREFIX_SEPARATOR);
+        }
+
+        clientScopes.get(organizationScope.getId()).getProtocolMappers().update(mapper.getId(), mapper);
+    }
+
+    private static String createOrganization(OrganizationsResource organizations, String name) {
+        OrganizationRepresentation organization = new OrganizationRepresentation();
+        organization.setName(name);
+        organization.setEnabled(true);
+
+        OrganizationDomainRepresentation domain = new OrganizationDomainRepresentation();
+        domain.setName(name);
+        organization.addDomain(domain);
+
+        return idOf(organizations.create(organization));
+    }
+
+    private static String createTopLevelGroup(OrganizationGroupsResource groups, String name) {
+        return idOf(groups.addTopLevelGroup(group(name)));
+    }
+
+    private static String createSubGroup(OrganizationGroupsResource groups, String parentId, String name) {
+        return idOf(groups.group(parentId).addSubGroup(group(name)));
+    }
+
+    private static GroupRepresentation group(String name) {
+        GroupRepresentation group = new GroupRepresentation();
+        group.setName(name);
+        return group;
+    }
+
+    private static String idOf(Response response) {
+        assumeThat(response.getStatus()).isIn(200, 201);
+        String location = response.getHeaderString("Location");
+        assumeThat(location).isNotNull();
+        return location.substring(location.lastIndexOf('/') + 1);
+    }
+}

--- a/src/test/java/de/sventorben/keycloak/kommons/orgs/OrganizationGroupsTest.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/orgs/OrganizationGroupsTest.java
@@ -1,0 +1,283 @@
+package de.sventorben.keycloak.kommons.orgs;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.GroupProvider;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.organization.OrganizationProvider;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static de.sventorben.keycloak.kommons.orgs.OrganizationGroups.Label.NAME;
+import static de.sventorben.keycloak.kommons.orgs.OrganizationGroups.Label.PATH;
+import static de.sventorben.keycloak.kommons.orgs.OrganizationGroups.Source.AUTO;
+import static de.sventorben.keycloak.kommons.orgs.OrganizationGroups.Source.CONVENTION;
+import static de.sventorben.keycloak.kommons.orgs.OrganizationGroups.Source.ORGANIZATION_GROUPS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the {@code source} x {@code label} x {@code prefix} matrix of the organization aware group mapper.
+ *
+ * <p>The flattening dimension sits in the mapper itself and is covered end-to-end by {@code OidcOrgGroupsIT}.
+ */
+class OrganizationGroupsTest {
+
+    private static final String ORGANIZATION_ID = "org-id";
+    private static final String ALIAS = "acme";
+
+    private final UserModel user = mock(UserModel.class);
+
+    // --- configuration parsing -------------------------------------------------------------------------------
+
+    @Test
+    void sourceDefaultsToAutoAndToleratesGarbage() {
+        assertThat(OrganizationGroups.Source.from(null)).isEqualTo(AUTO);
+        assertThat(OrganizationGroups.Source.from("  ")).isEqualTo(AUTO);
+        assertThat(OrganizationGroups.Source.from("nonsense")).isEqualTo(AUTO);
+        assertThat(OrganizationGroups.Source.from("organization-groups")).isEqualTo(ORGANIZATION_GROUPS);
+        assertThat(OrganizationGroups.Source.from("CONVENTION")).isEqualTo(CONVENTION);
+    }
+
+    @Test
+    void labelDefaultsToNameAndToleratesGarbage() {
+        assertThat(OrganizationGroups.Label.from(null)).isEqualTo(NAME);
+        assertThat(OrganizationGroups.Label.from("nonsense")).isEqualTo(NAME);
+        assertThat(OrganizationGroups.Label.from("path")).isEqualTo(PATH);
+    }
+
+    @Test
+    void prefixingIsPurelyTextual() {
+        assertThat(prefix(false, null).apply("leads", ALIAS)).isEqualTo("leads");
+        assertThat(prefix(true, null).apply("leads", ALIAS)).isEqualTo("acme_leads");
+        assertThat(prefix(true, null).apply("engineering/leads", ALIAS))
+            .isEqualTo("acme_engineering/leads");
+    }
+
+    @Test
+    void theSeparatorIsConfigurable() {
+        assertThat(prefix(true, ":").apply("leads", ALIAS)).isEqualTo("acme:leads");
+        assertThat(prefix(true, "::").apply("leads", ALIAS)).isEqualTo("acme::leads");
+        assertThat(prefix(true, "/").apply("engineering/leads", ALIAS))
+            .isEqualTo("acme/engineering/leads");
+    }
+
+    @Test
+    void anUnsetSeparatorKeepsTheHistoricalUnderscore() {
+        // The admin console cannot distinguish "unset" from "empty", so blank must not silently concatenate.
+        assertThat(prefix(true, null).apply("leads", ALIAS)).isEqualTo("acme_leads");
+        assertThat(prefix(true, "").apply("leads", ALIAS)).isEqualTo("acme_leads");
+        assertThat(prefix(true, "   ").apply("leads", ALIAS)).isEqualTo("acme_leads");
+    }
+
+    @Test
+    void theSeparatorIsIgnoredWhenNotPrefixing() {
+        assertThat(prefix(false, "::").apply("leads", ALIAS)).isEqualTo("leads");
+    }
+
+    // --- organization groups ---------------------------------------------------------------------------------
+
+    @Test
+    void organizationGroupsAsNames() {
+        KeycloakSession session = sessionWithOrganizationGroups();
+
+        assertThat(labels(session, ORGANIZATION_GROUPS, NAME, false)).containsExactly("sales", "leads");
+    }
+
+    @Test
+    void organizationGroupsAsPrefixedNames() {
+        KeycloakSession session = sessionWithOrganizationGroups();
+
+        assertThat(labels(session, ORGANIZATION_GROUPS, NAME, true)).containsExactly("acme_sales", "acme_leads");
+    }
+
+    @Test
+    void organizationGroupsAsPaths() {
+        KeycloakSession session = sessionWithOrganizationGroups();
+
+        // The nested group renders relative to its organization: Keycloak's path builder already stops at the
+        // internal group that roots the organization hierarchy.
+        assertThat(labels(session, ORGANIZATION_GROUPS, PATH, false)).containsExactly("sales", "engineering/leads");
+    }
+
+    @Test
+    void organizationGroupsAsPrefixedPaths() {
+        KeycloakSession session = sessionWithOrganizationGroups();
+
+        assertThat(labels(session, ORGANIZATION_GROUPS, PATH, true))
+            .containsExactly("acme_sales", "acme_engineering/leads");
+    }
+
+    // --- convention layout -----------------------------------------------------------------------------------
+
+    @Test
+    void conventionGroupsAsNames() {
+        KeycloakSession session = sessionWithConventionGroups();
+
+        assertThat(labels(session, CONVENTION, NAME, false)).containsExactly("developers");
+    }
+
+    @Test
+    void conventionGroupsAsPrefixedNames() {
+        KeycloakSession session = sessionWithConventionGroups();
+
+        assertThat(labels(session, CONVENTION, NAME, true)).containsExactly("acme_developers");
+    }
+
+    @Test
+    void conventionGroupsRenderTheSameForBothLabels() {
+        // The convention layout is flat by construction, so a path cannot differ from a name.
+        assertThat(labels(sessionWithConventionGroups(), CONVENTION, PATH, false)).containsExactly("developers");
+        assertThat(labels(sessionWithConventionGroups(), CONVENTION, PATH, true))
+            .containsExactly("acme_developers");
+    }
+
+    @Test
+    void anOrganizationOutsideTheConventionTreeContributesNothing() {
+        KeycloakSession session = sessionWithConventionGroups();
+        OrganizationModel other = organization("globex");
+
+        assertThat(OrganizationGroups.labelsFor(session, other, user, rendering(CONVENTION, NAME, false))).isNull();
+    }
+
+    @Test
+    void aMissingConventionRootContributesNothing() {
+        KeycloakSession session = session();
+        when(session.groups().getGroupByName(any(), eq(null), eq(OrganizationGroups.CONVENTION_ROOT_GROUP)))
+            .thenReturn(null);
+
+        assertThat(labels(session, CONVENTION, NAME, false)).isNull();
+    }
+
+    // --- auto ------------------------------------------------------------------------------------------------
+
+    @Test
+    void autoPrefersOrganizationGroupsWhenTheOrganizationHasAny() {
+        KeycloakSession session = sessionWithOrganizationGroups();
+
+        assertThat(labels(session, AUTO, NAME, false)).containsExactly("sales", "leads");
+    }
+
+    @Test
+    void autoFallsBackToTheConventionWhenTheOrganizationHasNoGroups() {
+        KeycloakSession session = sessionWithConventionGroups();
+
+        assertThat(labels(session, AUTO, NAME, false)).containsExactly("developers");
+    }
+
+    // --- guards ----------------------------------------------------------------------------------------------
+
+    @Test
+    void withoutAnOrganizationOrUserThereIsNothingToRender() {
+        KeycloakSession session = sessionWithOrganizationGroups();
+
+        assertThat(OrganizationGroups.labelsFor(session, null, user, rendering(AUTO, NAME, false))).isNull();
+        assertThat(OrganizationGroups.labelsFor(session, organization(ALIAS), null, rendering(AUTO, NAME, false))).isNull();
+    }
+
+    // --- fixtures --------------------------------------------------------------------------------------------
+
+    private List<String> labels(KeycloakSession session, OrganizationGroups.Source source,
+                                OrganizationGroups.Label label, boolean prefix) {
+        return OrganizationGroups.labelsFor(session, organization(ALIAS), user, rendering(source, label, prefix));
+    }
+
+    private static OrganizationGroups.AliasPrefix prefix(boolean enabled, String separator) {
+        return OrganizationGroups.AliasPrefix.of(enabled, separator);
+    }
+
+    private static OrganizationGroups.Rendering rendering(OrganizationGroups.Source source,
+                                                          OrganizationGroups.Label label, boolean prefixWithAlias) {
+        return new OrganizationGroups.Rendering(source, label, prefix(prefixWithAlias, null));
+    }
+
+    private static OrganizationModel organization(String alias) {
+        OrganizationModel organization = mock(OrganizationModel.class);
+        when(organization.getId()).thenReturn(ORGANIZATION_ID);
+        when(organization.getAlias()).thenReturn(alias);
+        return organization;
+    }
+
+    private static KeycloakSession session() {
+        RealmModel realm = mock(RealmModel.class);
+        KeycloakContext context = mock(KeycloakContext.class);
+        when(context.getRealm()).thenReturn(realm);
+
+        KeycloakSession session = mock(KeycloakSession.class);
+        when(session.getContext()).thenReturn(context);
+        when(session.groups()).thenReturn(mock(GroupProvider.class));
+        when(session.getProvider(OrganizationProvider.class)).thenReturn(mock(OrganizationProvider.class));
+        return session;
+    }
+
+    /**
+     * An organization with a top level group {@code sales} and a nested group {@code engineering/leads}, both of
+     * which the user is a direct member of.
+     */
+    private KeycloakSession sessionWithOrganizationGroups() {
+        KeycloakSession session = session();
+        OrganizationProvider organizations = session.getProvider(OrganizationProvider.class);
+
+        GroupModel internal = organizationGroup(ORGANIZATION_ID, null);
+        GroupModel sales = organizationGroup("sales", internal);
+        GroupModel engineering = organizationGroup("engineering", internal);
+        GroupModel leads = organizationGroup("leads", engineering);
+
+        when(organizations.getTopLevelGroups(any(), anyInt(), anyInt()))
+            .thenAnswer(invocation -> Stream.of(sales, engineering));
+        when(organizations.getOrganizationGroupsByMember(any(), eq(user)))
+            .thenAnswer(invocation -> Stream.of(sales, leads));
+
+        return session;
+    }
+
+    /**
+     * A realm using the {@code /organizations/acme/developers} convention and no organization groups at all.
+     */
+    private KeycloakSession sessionWithConventionGroups() {
+        KeycloakSession session = session();
+
+        when(session.getProvider(OrganizationProvider.class).getTopLevelGroups(any(), anyInt(), anyInt()))
+            .thenAnswer(invocation -> Stream.empty());
+
+        GroupModel developers = mock(GroupModel.class);
+        when(developers.getName()).thenReturn("developers");
+        when(user.isMemberOf(developers)).thenReturn(true);
+
+        GroupModel aliasGroup = mock(GroupModel.class);
+        when(aliasGroup.getName()).thenReturn(ALIAS);
+        when(aliasGroup.getSubGroupsStream()).thenAnswer(invocation -> Stream.of(developers));
+
+        GroupModel root = mock(GroupModel.class);
+        when(root.getSubGroupsStream()).thenAnswer(invocation -> Stream.of(aliasGroup));
+
+        when(session.groups().getGroupByName(any(), eq(null), eq(OrganizationGroups.CONVENTION_ROOT_GROUP)))
+            .thenReturn(root);
+
+        return session;
+    }
+
+    /**
+     * Mocks an organization group so that Keycloak's real path builder can walk it. The builder stops at the group
+     * named after the organization id, which is how a path ends up relative to its organization.
+     */
+    private static GroupModel organizationGroup(String name, GroupModel parent) {
+        OrganizationModel organization = mock(OrganizationModel.class);
+        when(organization.getId()).thenReturn(ORGANIZATION_ID);
+
+        GroupModel group = mock(GroupModel.class);
+        when(group.getName()).thenReturn(name);
+        when(group.getParent()).thenReturn(parent);
+        when(group.getOrganization()).thenReturn(organization);
+        return group;
+    }
+}

--- a/src/test/resources/OrganizationGroupsMapperIT-realm.json
+++ b/src/test/resources/OrganizationGroupsMapperIT-realm.json
@@ -1,0 +1,2525 @@
+{
+  "id": "586754da-6fcc-4bc6-9ee6-937b0542838f",
+  "realm": "OrganizationGroupsMapperIT",
+  "displayName": "OrganizationGroupsMapperIT",
+  "displayNameHtml": "",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "bruteForceStrategy": "MULTIPLE",
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "115c84cb-fe87-4db9-af8b-cce332598113",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "0daae8cd-7ca4-4412-ae7c-edfd902cfd58",
+        "attributes": {}
+      },
+      {
+        "id": "bb4f9266-874e-4a91-8e7b-3e27ece39deb",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "0daae8cd-7ca4-4412-ae7c-edfd902cfd58",
+        "attributes": {}
+      },
+      {
+        "id": "b57da48c-25a6-45d3-8124-0a890cb7dff6",
+        "name": "default-roles-oidcorggroupsit",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "view-profile",
+              "manage-account"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "0daae8cd-7ca4-4412-ae7c-edfd902cfd58",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "realm-management": [
+        {
+          "id": "976c3968-1409-4b64-b8f0-4d5f6ad5ebb1",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "1b567b3f-b936-4f12-b5e5-7bebdea5bcde",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "0826cd96-2c25-437c-b136-7ae7a3e05d7c",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "f3d75004-b8df-489b-a9bf-781944afd1fc",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "ea93b21b-991e-410e-b038-d66b850617f9",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "8a9f0b4b-ad8c-4ecb-84cb-715fb82c26c3",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "173f794b-4fb5-471a-a3fc-87c909cd1433",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "d41e927d-b3bc-4685-bd28-f571b4f6d314",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "bd138c1d-a69b-46f3-94de-686aca66eb2d",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "f68af010-d0c4-4218-9b75-eb3d83b4551c",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "420b4beb-bdd6-4c64-9ce1-62652f5120c2",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "6dd5f590-cabe-42b7-ad39-843871c5219a",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "b931414f-9f64-450d-b95f-758236f5195d",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "b36261f4-d9e6-4a41-834e-e01e6583fa10",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "f0bd6db7-8c04-4d9a-8af7-69726ce00c55",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "041262fa-7e2e-4dd1-abcc-70aba5c7525b",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "76c098df-42e2-4352-b243-80a779145bc8",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-users",
+                "query-groups"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "37bb73fb-9e1f-469e-9551-cd563b00ba2e",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-realms",
+                "query-clients",
+                "create-client",
+                "view-realm",
+                "view-clients",
+                "query-users",
+                "manage-clients",
+                "query-groups",
+                "manage-events",
+                "manage-identity-providers",
+                "manage-users",
+                "view-authorization",
+                "view-identity-providers",
+                "view-events",
+                "impersonation",
+                "manage-realm",
+                "view-users",
+                "manage-authorization"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        },
+        {
+          "id": "5d0809c2-f708-44cd-8e69-85a194623ab2",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+          "attributes": {}
+        }
+      ],
+      "test": [],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "5a9b262c-e26c-41a0-b633-a0373c5e2894",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "01782ac3-d818-4367-8cec-e61fa9cff13e",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "1540b41d-e716-4a28-b516-12d69c819ef9",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "f3c8f4b0-b851-442c-803d-b2354fc4da57",
+          "attributes": {}
+        },
+        {
+          "id": "2a67bac4-d666-4bb0-ad75-2e15fd0961c8",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "f3c8f4b0-b851-442c-803d-b2354fc4da57",
+          "attributes": {}
+        },
+        {
+          "id": "6180b13e-9515-4233-8fc3-f821ee97dae1",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "f3c8f4b0-b851-442c-803d-b2354fc4da57",
+          "attributes": {}
+        },
+        {
+          "id": "b62bde9b-5515-46a1-b02b-3bd018141918",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "f3c8f4b0-b851-442c-803d-b2354fc4da57",
+          "attributes": {}
+        },
+        {
+          "id": "1e11a452-d06d-4443-9a95-9c54c5b73fb0",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "f3c8f4b0-b851-442c-803d-b2354fc4da57",
+          "attributes": {}
+        },
+        {
+          "id": "cb176102-222b-456b-bd8f-7fc43ac7372f",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "f3c8f4b0-b851-442c-803d-b2354fc4da57",
+          "attributes": {}
+        },
+        {
+          "id": "116ae060-e3e9-4cff-8935-173da1a980fe",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "f3c8f4b0-b851-442c-803d-b2354fc4da57",
+          "attributes": {}
+        },
+        {
+          "id": "a52a5da1-e794-4551-b9d0-0b36b874832c",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "f3c8f4b0-b851-442c-803d-b2354fc4da57",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "b57da48c-25a6-45d3-8124-0a890cb7dff6",
+    "name": "default-roles-oidcorggroupsit",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "0daae8cd-7ca4-4412-ae7c-edfd902cfd58"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "users": [
+    {
+      "id": "139020a3-4459-43b1-a92f-d90e5cf093a1",
+      "createdTimestamp": 1632070461116,
+      "username": "test",
+      "firstName": "Test",
+      "lastName": "User",
+      "enabled": true,
+      "totp": false,
+      "email": "test@example.com",
+      "emailVerified": true,
+      "credentials": [
+        {
+          "id": "b7a13463-c361-4893-bae2-a7c28723ba41",
+          "type": "password",
+          "createdDate": 1632070469930,
+          "secretData": "{\"value\":\"f0KV+30selJs9QbGBR/Yl62Eu0fRP2EUudbUEYMLgEdeXrRMKZFMtY3OlfG3W9a6ygNflxj9ysUv4j/RwnMN8g==\",\"salt\":\"ZAaXBhufypfX/dSuy9+Pdg==\",\"additionalParameters\":{}}",
+          "credentialData": "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-test-realm"
+      ],
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account",
+          "view-groups"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "f3c8f4b0-b851-442c-803d-b2354fc4da57",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/OidcOrgGroupsIT/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/OidcOrgGroupsIT/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "1b91bf0d-6c44-48cb-aa58-5445491a3f31",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/OidcOrgGroupsIT/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/OidcOrgGroupsIT/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "78f0b68b-3bba-4ad5-a3ac-87593e0139f0",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "87202bb0-0c14-4a90-9aa7-16a05a32a8d8",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "01782ac3-d818-4367-8cec-e61fa9cff13e",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "1a5acf6e-4aa7-46d7-9970-da6ce5212235",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "bb2f50b0-af23-4c93-b742-b3a96c944f2f",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/OidcOrgGroupsIT/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/OidcOrgGroupsIT/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "1a81e9ea-7d42-4655-9a8a-216b8e99a1f4",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "5b723d30-4c4f-4bbd-ba17-2f30fcaddfa0",
+      "clientId": "test",
+      "name": "",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "frontchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "display.on.consent.screen": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "organization",
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "a791b706-4fac-4611-a5ef-bfdf791d6bca",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "de213131-2013-40af-8772-dbe3a22351d1",
+      "name": "organization",
+      "description": "Additional claims about the organization a subject belongs to",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${organizationScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "5fdec0ca-3cb3-4461-9e23-c2709f397859",
+          "name": "organization",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "organization",
+            "jsonType.label": "JSON",
+            "multivalued": "true",
+            "addOrganizationAttributes": "true",
+            "addOrganizationId": false
+          }
+        },
+        {
+          "id": "472c2644-e412-4de9-b8af-47db622c97e3",
+          "name": "org-groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "kommons-orgs-group-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "lightweight.claim": "false",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "prefix.groups.with.organization": "false",
+            "emit.flattend.group.claim": "false"
+          }
+        }
+      ]
+    },
+    {
+      "id": "7013764b-68a3-4583-85c2-5f8ace418ca4",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "${rolesScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "02bacc24-f705-43b7-a52f-c4992fa547de",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "75cc51c7-6648-40c4-b6cc-c1e770b8479a",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "4e694d53-28b1-466c-a3d7-c442af8ed209",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "1f615374-581b-498a-96bc-c79696cc0c15",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "0430b837-668d-4d2b-ab11-fbbf72817aa0",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "dbeccc78-34a4-44f1-baa4-5648d2375a55",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "639e9475-fe43-4e65-981e-9007c1bf1f26",
+      "name": "service_account",
+      "description": "Specific scope for a client enabled for service accounts",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "6c619278-12f9-4014-9601-361a790e6a6e",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4dbdbe52-d124-45ae-bb53-52888a8a33fc",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c4070a64-235a-4f96-94da-56776a5acf14",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "77841cf7-d473-4351-a5a3-734d8966eaee",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "ee2c0b41-496b-4ca2-aee1-30b148de6e26",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "e93a3372-0605-48c6-a870-891845c6f3b7",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "6bf0e6f6-b116-45e5-927f-6b3e8a4a5ec1",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "85979488-3743-4c46-91cd-aececd8d72c4",
+      "name": "saml_organization",
+      "description": "Organization Membership",
+      "protocol": "saml",
+      "attributes": {
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "cd5e2354-b041-461f-aa51-656e18385fc8",
+          "name": "organization",
+          "protocol": "saml",
+          "protocolMapper": "saml-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "255f7125-0387-4e48-a9bd-27cf672bfc36",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${phoneScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "b51179fe-6357-4faa-9ca7-54debb09bc5d",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7e6bcc1b-000f-4020-b943-377f465fc212",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "10c283d5-5d84-4a45-ad06-943a28b25f2c",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "97fda440-f02d-45f3-9d98-b96a1e0e13cb",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "00ae99bc-85dc-4d4b-a948-9f271f5e1d36",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${emailScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "2a5f8b5b-1862-417a-a6d5-e9b59791f70b",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "2f28d16f-f032-48bd-8369-feec79a21294",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "0f2ff089-2384-491e-8168-216bf029167b",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${addressScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "660cf0aa-7a06-492e-8ac9-6c4388e7cc98",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "introspection.token.claim": "true",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "4a009a98-2716-4219-9983-de1daf0a227d",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${profileScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "921588d3-754c-4721-8851-fc042af0ffcd",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "956bd3fc-24ed-4c0f-89fd-ec625018a31f",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b470b909-f946-48b6-a462-da611364a969",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3837cb73-81fd-48d1-a178-4b5557b1e47b",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c7d1a345-046d-48f3-91c5-ee32019ec346",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "381c0de5-f6ef-41d0-8c31-818254849c16",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "61c34c72-45d4-4b7e-9ca4-16f3a38e803b",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b4d90df8-e61f-4b68-a4a6-78bd0c68c990",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "57f7af1c-7caa-4ec8-bc02-7e3d92ecf31d",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ffd04886-4345-4573-80b1-c893318f090e",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ac86f3c9-79fa-4ab7-a1d3-c35bc35927aa",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "84f0a49a-496f-4cf4-b198-457f0352d319",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0c215e9f-9fd0-41ee-a976-7f3e8875fc6d",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d8154098-04a3-47af-9e83-64c0a08de5a0",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "387e4a06-c7ca-4d2c-8b80-997b3f45dd4c",
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "8343462a-8b6d-4d0b-b7de-15ebbbd4935c",
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "id": "60b80e17-e2bd-48a2-86a0-5e2a71b73707",
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "saml_organization",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr",
+    "basic"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt",
+    "organization"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "8fee1d0b-f8f1-4244-b364-9090b79e5a78",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "b85a7f50-2c5c-4c81-b01b-44fdf4af3340",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "f79b2486-a59d-41ee-97ba-d7a2805d9c6c",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "b5dcc344-8d59-459e-bc41-0019ffa6b074",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "9ada0db3-13bd-4816-a9e8-428b252818c3",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-full-name-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-address-mapper",
+            "saml-user-property-mapper",
+            "oidc-usermodel-property-mapper",
+            "saml-role-list-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-sha256-pairwise-sub-mapper"
+          ]
+        }
+      },
+      {
+        "id": "74080662-d85d-4ed3-b5fd-fe70b5cf41e2",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "921e09fe-ad94-4e52-a96b-d9bcfbc81b89",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-full-name-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-attribute-mapper",
+            "saml-user-property-mapper"
+          ]
+        }
+      },
+      {
+        "id": "0cf740d9-2e9a-431f-9b1b-43f0c9cfab98",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "5bc79193-33f0-4f24-8378-ef17d78ee7fe",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "07b754af-c8ac-4208-bf40-4a51239e06be",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "RSA-OAEP"
+          ]
+        }
+      },
+      {
+        "id": "00474d49-3c88-45ea-9564-62ae846f2709",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS512"
+          ]
+        }
+      },
+      {
+        "id": "886e20ee-fc68-4b55-b577-d52b161e53a5",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
+    {
+      "id": "613831e0-1b25-455d-884f-488f8a2ad048",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "07f99516-be7b-4c42-b5e0-0e4011efbd9c",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "99841eb8-e16f-41ba-8695-8a21e1adeb85",
+      "alias": "Browser - Conditional Organization",
+      "description": "Flow to determine if the organization identity-first login is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "organization",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "79f9f75b-7925-4814-aae7-cdd35717092e",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e2890ff0-55c6-4ec2-8916-94e0edbbbd16",
+      "alias": "First Broker Login - Conditional Organization",
+      "description": "Flow to determine if the authenticator that adds organization members is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "idp-add-organization-member",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "091fef1e-3703-4cee-83b0-e3fcdf1f3244",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "34673b00-d0ac-4dc7-8778-51868155d12d",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "222b5d5e-6836-4f34-a04c-6ae9b88fb636",
+      "alias": "Organization",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a7409396-67f6-41c6-9c05-7ef5ae0c75d5",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "d8cff9b5-bedc-448c-ba95-22d9c3a9d3c8",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "53c7ef91-2eab-487a-8243-70d3acedbc9d",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "b16b463d-71fd-4a88-a6c8-2c7bb2db3c2a",
+      "alias": "browser",
+      "description": "Browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 26,
+          "autheticatorFlow": true,
+          "flowAlias": "Organization",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "ede4198c-ed6e-4c7f-aaa6-21185c1dd04e",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "f3423203-ed9b-4147-b6c4-881b41f80c97",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "c1c4c9aa-f511-4b34-8bac-33a3077d3c46",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "ba3188f8-881b-4ee3-9657-c9a3e555aefc",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 50,
+          "autheticatorFlow": true,
+          "flowAlias": "First Broker Login - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "1d3ddab3-1ac8-4a37-8f32-a8a4ad8c3c41",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "cfcde091-fe46-4d71-92f2-1840683a3381",
+      "alias": "registration",
+      "description": "Registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "31a44574-1fa6-4b03-8ad8-bfd374ddc0e2",
+      "alias": "registration form",
+      "description": "Registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a839c2bd-1c4c-44bd-b63d-a76ad91729ca",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "40207554-fe17-46b8-84e0-ed3b822c95f3",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "554dec19-09d1-49d7-ad64-2abf5d63e476",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "2a7dcd57-df54-465b-bbe3-a318663692cf",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 90,
+      "config": {}
+    },
+    {
+      "alias": "delete_credential",
+      "name": "Delete Credential",
+      "providerId": "delete_credential",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 100,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DevicePollingInterval": "5",
+    "clientOfflineSessionMaxLifespan": "0",
+    "clientSessionIdleTimeout": "0",
+    "clientOfflineSessionIdleTimeout": "0",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false",
+    "cibaExpiresIn": "120",
+    "oauth2DeviceCodeLifespan": "600",
+    "saml.signature.algorithm": "",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "0",
+    "frontendUrl": "",
+    "acr.loa.map": "{}"
+  },
+  "keycloakVersion": "26.2.5",
+  "userManagedAccessAllowed": false,
+  "organizationsEnabled": true,
+  "verifiableCredentialsEnabled": false,
+  "adminPermissionsEnabled": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}


### PR DESCRIPTION
Closes #114

Teaches the Organization-aware Group Mapper to read Keycloak's own organization groups, while keeping **Emit Flattened Group Claim** and **Prefix Group Names with Organization Alias** working for them.

| Option | Key | Values | Default |
|---|---|---|---|
| Where to read groups from | `kommons.orgs.group.source` | `auto` / `organization-groups` / `convention` | `auto` |
| How to render a group | `kommons.orgs.group.label` | `name` / `path` | `name` |
| Separator between alias and group | `kommons.orgs.prefix.separator` | any string | `_` |

All defaults reproduce the previous output exactly.

`auto` is resolved **per organization**, so a realm can be migrated one organization at a time — during a migration one token may legitimately carry native groups for one organization and convention groups for another.

## The matrix

For a user in `acme` who is a member of `sales` and of the nested `engineering/leads`:

| label | prefix | flatten | Claim |
|---|---|---|---|
| `name` | off | off | `"organization": { "acme": { "groups": ["sales", "leads"] } }` |
| `name` | on | on | `"groups": ["acme_sales", "acme_leads"]` |
| `path` | off | on | `"groups": ["sales", "engineering/leads"]` |
| `path` | on | on | `"groups": ["acme_sales", "acme_engineering/leads"]` |

The prefix is applied once at the front of the whole label, never inside a path.

## Two things worth knowing

**No organization id ever reaches the claim.** Keycloak roots each organization's hierarchy in an internal group named after the organization **ID**, but its own path builder already stops there — *"For org groups: stop recursion at internal org group (name equals org UUID)"* (`KeycloakModelUtils`). So `path` yields `engineering/leads`, not `/<uuid>/engineering/leads`. The unit tests exercise Keycloak's real path builder rather than asserting an assumption.

**The separator matters more than it looks.** `acme_dev_leads` cannot be split back apart: is the organization `acme` and the group `dev_leads`, or `acme_dev` and `leads`? Anything downstream that parses the value needs a delimiter that cannot occur in either part. A blank value falls back to `_`, because the Admin Console cannot distinguish "unset" from "deliberately empty" and silently producing `acmeleads` would be worse.

## Testing

- `OrganizationGroupsTest` — 18 unit tests covering the `source` x `label` x `prefix` matrix, config parsing including garbage input, and the separator rules.
- `OrganizationGroupsMapperIT` — 5 integration tests covering `label` x `prefix` x `flatten` end to end against a realm with **no** convention tree, so `auto` has to resolve to organization groups. Includes the custom separator case.
- `OidcOrgGroupsIT` is deliberately **untouched** and still passes — that is the backward compatibility guard for the convention layout.

## Notes for review

- `docs/org_aware_group_mapper.md` gained both layouts, the three new options, the full 8-row matrix, and a section on combining this with Single Organization per Session — the short version being that this mapper emits groups for every organization it resolves, so a flattened claim is only unambiguous once the request is constrained to one organization.
- No `pom.xml` change was needed: `keycloak-admin-client:26.0.11` already ships `OrganizationGroupsResource`.
