### PR TITLE
docs: move Notice for Developers last and extend the copyright year

### DIFF
--- a/docs/_includes/footer_custom.html
+++ b/docs/_includes/footer_custom.html
@@ -1,1 +1,1 @@
-&copy; 2025 Sven-Torben Janus
+&copy; 2025-2026 Sven-Torben Janus

--- a/docs/developer_info.md
+++ b/docs/developer_info.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Notice for Developers
-nav_order: 4
+nav_order: 7
 ---
 
 # Notice for Developers


### PR DESCRIPTION
Two documentation chores; no issue, as neither changes behaviour.

**Sidebar order.** `Release notes` is an *external* navigation link (`nav_external_links` in `_config.yml`), and just-the-docs renders external links after all internal pages. Giving `Notice for Developers` the highest `nav_order` therefore places it directly before `Release notes`, which is the requested order.

This also resolves `nav_order: 4` being used twice (`developer_info.md` and `unusual_login_time_condition.md`). Resulting order:

1. Introduction
2. Installation
3. Organization-aware Group Mapper
4. Unusual Login Time Condition
5. Multi Client Attributes Claims Mapper
6. Single Organization per Session
7. Notice for Developers
→ *Release notes*, *Contributing*, *Issue tracker* (external)

**Copyright.** Footer extended to 2025-2026.