### PR TITLE
test(auth): cover the unusual login time condition

### DIFF
--- a/src/main/java/de/sventorben/keycloak/kommons/auth/UnusualLoginTimeConditionalAuthenticator.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/auth/UnusualLoginTimeConditionalAuthenticator.java
@@ -7,12 +7,25 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 
+import java.time.Clock;
 import java.time.LocalTime;
-import java.time.ZoneOffset;
 
 public final class UnusualLoginTimeConditionalAuthenticator implements ConditionalAuthenticator {
 
     private static final Logger LOG = Logger.getLogger(UnusualLoginTimeConditionalAuthenticator.class);
+
+    private final Clock clock;
+
+    public UnusualLoginTimeConditionalAuthenticator() {
+        this(Clock.systemUTC());
+    }
+
+    /**
+     * Login times are recorded in UTC, so the clock has to report UTC as well.
+     */
+    UnusualLoginTimeConditionalAuthenticator(Clock clock) {
+        this.clock = clock;
+    }
 
     @Override
     public boolean matchCondition(AuthenticationFlowContext context) {
@@ -29,10 +42,16 @@ public final class UnusualLoginTimeConditionalAuthenticator implements Condition
         return !isInRange(user, skew);
     }
 
-    private static boolean isInRange(UnusualLoginTimeUserWrapper user, int skew) {
+    private boolean isInRange(UnusualLoginTimeUserWrapper user, int skew) {
+        if (!user.hasRecordedLoginTimes()) {
+            // Nothing has been recorded yet, so no time can be unusual. Applying the skew to the MIN..MAX default
+            // would wrap it around midnight and mark almost every login as unusual.
+            return true;
+        }
+
         LocalTime adjustedStart = user.getMinTime().minusMinutes(skew);
         LocalTime adjustedEnd = user.getMaxTime().plusMinutes(skew);
-        LocalTime loginTime = LocalTime.now(ZoneOffset.UTC);
+        LocalTime loginTime = LocalTime.now(clock);
         return isInRange(adjustedStart, adjustedEnd, loginTime);
     }
 

--- a/src/main/java/de/sventorben/keycloak/kommons/auth/UnusualLoginTimeUserWrapper.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/auth/UnusualLoginTimeUserWrapper.java
@@ -17,6 +17,14 @@ final class UnusualLoginTimeUserWrapper {
         this.user = user;
     }
 
+    /**
+     * Whether any successful login time has been recorded for this user yet. Without one there is no baseline to
+     * compare against, so no login can be unusual.
+     */
+    boolean hasRecordedLoginTimes() {
+        return user.getAttributeStream(USER_ATTRIBUTE_USUAL_LOGIN_TIMES).findAny().isPresent();
+    }
+
     LocalTime getMinTime() {
         return user.getAttributeStream(USER_ATTRIBUTE_USUAL_LOGIN_TIMES)
             .map(LocalTime::parse)

--- a/src/test/java/de/sventorben/keycloak/kommons/auth/UnusualLoginTimeConditionalAuthenticatorConfigTest.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/auth/UnusualLoginTimeConditionalAuthenticatorConfigTest.java
@@ -1,0 +1,70 @@
+package de.sventorben.keycloak.kommons.auth;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for reading the clock skew of the unusual login time condition.
+ */
+class UnusualLoginTimeConditionalAuthenticatorConfigTest {
+
+    private static final String CONFIG_SKEW_MINUTES = "kommons.skew.minutes";
+    private static final int DEFAULT_SKEW_MINUTES = 15;
+
+    @Test
+    void anUnconfiguredAuthenticatorUsesTheDefaultSkew() {
+        assertThat(config(null).getSkew()).isEqualTo(DEFAULT_SKEW_MINUTES);
+    }
+
+    @Test
+    void anAuthenticatorConfigWithoutValuesUsesTheDefaultSkew() {
+        assertThat(config(new AuthenticatorConfigModel()).getSkew()).isEqualTo(DEFAULT_SKEW_MINUTES);
+        assertThat(config(withConfig(new HashMap<>())).getSkew()).isEqualTo(DEFAULT_SKEW_MINUTES);
+    }
+
+    @Test
+    void aConfiguredSkewIsUsed() {
+        assertThat(config(withConfig(Map.of(CONFIG_SKEW_MINUTES, "45"))).getSkew()).isEqualTo(45);
+    }
+
+    @Test
+    void aSkewOfZeroIsHonoured() {
+        // Zero must not silently fall back to the default, it means "no tolerance at all".
+        assertThat(config(withConfig(Map.of(CONFIG_SKEW_MINUTES, "0"))).getSkew()).isZero();
+    }
+
+    @Test
+    void aNonNumericSkewIsRejectedLoudly() {
+        // Better to fail than to silently authenticate with a skew nobody configured.
+        assertThatThrownBy(() -> config(withConfig(Map.of(CONFIG_SKEW_MINUTES, "soon"))).getSkew())
+            .isInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
+    void theSkewIsExposedAsAConfigProperty() {
+        assertThat(UnusualLoginTimeConditionalAuthenticatorConfig.PROPERTIES)
+            .singleElement()
+            .satisfies(property -> {
+                assertThat(property.getName()).isEqualTo(CONFIG_SKEW_MINUTES);
+                assertThat(property.getType()).isEqualTo(ProviderConfigProperty.INTEGER_TYPE);
+                assertThat(property.getDefaultValue()).isEqualTo(DEFAULT_SKEW_MINUTES);
+            });
+    }
+
+    private static UnusualLoginTimeConditionalAuthenticatorConfig config(AuthenticatorConfigModel model) {
+        return new UnusualLoginTimeConditionalAuthenticatorConfig(model);
+    }
+
+    private static AuthenticatorConfigModel withConfig(Map<String, String> values) {
+        AuthenticatorConfigModel model = new AuthenticatorConfigModel();
+        model.setConfig(new HashMap<>(values));
+        return model;
+    }
+}

--- a/src/test/java/de/sventorben/keycloak/kommons/auth/UnusualLoginTimeConditionalAuthenticatorTest.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/auth/UnusualLoginTimeConditionalAuthenticatorTest.java
@@ -1,0 +1,157 @@
+package de.sventorben.keycloak.kommons.auth;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.UserModel;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for deciding whether a login time is unusual.
+ *
+ * <p>The authenticator is handed a fixed clock, so the decision is driven end to end: recorded login times and the
+ * configured skew produce a range, and the login time is checked against it.
+ */
+class UnusualLoginTimeConditionalAuthenticatorTest {
+
+    private static final String USUAL_LOGIN_TIMES = "kommons.usualLoginTimes";
+    private static final String SKEW_MINUTES = "kommons.skew.minutes";
+
+    // --- ordinary range, e.g. 08:00 - 20:00 ---------------------------------------------------------------------
+
+    @Test
+    void aTimeInsideAnOrdinaryRangeIsNotUnusual() {
+        assertThat(isUnusualAt("12:00", 0, "08:00", "20:00")).isFalse();
+    }
+
+    @Test
+    void bothEndsOfAnOrdinaryRangeCount() {
+        assertThat(isUnusualAt("08:00", 0, "08:00", "20:00")).isFalse();
+        assertThat(isUnusualAt("20:00", 0, "08:00", "20:00")).isFalse();
+    }
+
+    @Test
+    void aTimeOutsideAnOrdinaryRangeIsUnusual() {
+        assertThat(isUnusualAt("07:59", 0, "08:00", "20:00")).isTrue();
+        assertThat(isUnusualAt("20:01", 0, "08:00", "20:00")).isTrue();
+        assertThat(isUnusualAt("03:00", 0, "08:00", "20:00")).isTrue();
+    }
+
+    // --- range wrapping around midnight -------------------------------------------------------------------------
+    // A single login at 00:10 with a skew of 15 minutes spans 23:55 - 00:25, i.e. across midnight.
+
+    @Test
+    void aTimeOnEitherSideOfMidnightIsInAWrappingRange() {
+        assertThat(isUnusualAt("23:58", 15, "00:10")).isFalse();
+        assertThat(isUnusualAt("00:20", 15, "00:10")).isFalse();
+    }
+
+    @Test
+    void bothEndsOfAWrappingRangeCount() {
+        assertThat(isUnusualAt("23:55", 15, "00:10")).isFalse();
+        assertThat(isUnusualAt("00:25", 15, "00:10")).isFalse();
+    }
+
+    @Test
+    void theMiddleOfTheDayIsOutsideAWrappingRange() {
+        assertThat(isUnusualAt("12:00", 15, "00:10")).isTrue();
+        assertThat(isUnusualAt("02:00", 15, "00:10")).isTrue();
+        assertThat(isUnusualAt("23:54", 15, "00:10")).isTrue();
+    }
+
+    @Test
+    void aRangeAlsoWrapsWhenTheSkewPushesTheEndPastMidnight() {
+        // 23:50 with a skew of 15 minutes spans 23:35 - 00:05.
+        assertThat(isUnusualAt("00:03", 15, "23:50")).isFalse();
+        assertThat(isUnusualAt("00:06", 15, "23:50")).isTrue();
+    }
+
+    // --- skew ---------------------------------------------------------------------------------------------------
+
+    @Test
+    void theSkewWidensTheRangeOnBothSides() {
+        assertThat(isUnusualAt("08:45", 15, "09:00")).isFalse();
+        assertThat(isUnusualAt("09:15", 15, "09:00")).isFalse();
+        assertThat(isUnusualAt("08:44", 15, "09:00")).isTrue();
+        assertThat(isUnusualAt("09:16", 15, "09:00")).isTrue();
+    }
+
+    @Test
+    void withoutSkewASingleRecordedTimeMatchesOnlyThatInstant() {
+        assertThat(isUnusualAt("09:00", 0, "09:00")).isFalse();
+        assertThat(isUnusualAt("09:01", 0, "09:00")).isTrue();
+    }
+
+    // --- condition ----------------------------------------------------------------------------------------------
+
+    @Test
+    void withoutAUserTheConditionDoesNotMatch() {
+        AuthenticationFlowContext context = mock(AuthenticationFlowContext.class);
+        AuthenticationExecutionModel execution = new AuthenticationExecutionModel();
+        execution.setId("execution-id");
+        when(context.getExecution()).thenReturn(execution);
+        when(context.getUser()).thenReturn(null);
+
+        assertThat(newAuthenticator().matchCondition(context)).isFalse();
+    }
+
+    @Test
+    void aUserWithoutHistoryNeverLoginsAtAnUnusualTime() {
+        // Without a baseline every login would otherwise be flagged, because the default MIN..MAX range wraps
+        // around midnight once the skew is applied. The outcome does not depend on the time, so this is the one
+        // case that can be decided on the system clock the factory hands out.
+        assertThat(new UnusualLoginTimeConditionalAuthenticator().matchCondition(contextWith(mockUser()))).isFalse();
+    }
+
+    @Test
+    void theAuthenticatorNeedsAUser() {
+        assertThat(newAuthenticator().requiresUser()).isTrue();
+    }
+
+    // --- helpers ------------------------------------------------------------------------------------------------
+
+    private static boolean isUnusualAt(String nowUtc, int skew, String... recordedLoginTimes) {
+        AuthenticationFlowContext context = contextWith(mockUser(recordedLoginTimes), skew);
+        return newAuthenticator(nowUtc).matchCondition(context);
+    }
+
+    private static UnusualLoginTimeConditionalAuthenticator newAuthenticator() {
+        return newAuthenticator("12:00");
+    }
+
+    private static UnusualLoginTimeConditionalAuthenticator newAuthenticator(String nowUtc) {
+        Clock clock = Clock.fixed(Instant.parse("2026-01-01T" + nowUtc + ":00Z"), ZoneOffset.UTC);
+        return new UnusualLoginTimeConditionalAuthenticator(clock);
+    }
+
+    private static UserModel mockUser(String... recordedLoginTimes) {
+        UserModel user = mock(UserModel.class);
+        // The wrapper walks the attribute more than once, so every call needs a fresh stream.
+        when(user.getAttributeStream(USUAL_LOGIN_TIMES)).thenAnswer(invocation -> Stream.of(recordedLoginTimes));
+        return user;
+    }
+
+    private static AuthenticationFlowContext contextWith(UserModel user) {
+        return contextWith(user, 15);
+    }
+
+    private static AuthenticationFlowContext contextWith(UserModel user, int skew) {
+        AuthenticatorConfigModel configModel = new AuthenticatorConfigModel();
+        configModel.setConfig(Map.of(SKEW_MINUTES, String.valueOf(skew)));
+
+        AuthenticationFlowContext context = mock(AuthenticationFlowContext.class);
+        when(context.getUser()).thenReturn(user);
+        when(context.getAuthenticatorConfig()).thenReturn(configModel);
+        return context;
+    }
+}

--- a/src/test/java/de/sventorben/keycloak/kommons/auth/UnusualLoginTimeUserWrapperTest.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/auth/UnusualLoginTimeUserWrapperTest.java
@@ -1,0 +1,105 @@
+package de.sventorben.keycloak.kommons.auth;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.UserModel;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for reading and recording the usual login times of a user.
+ */
+class UnusualLoginTimeUserWrapperTest {
+
+    private static final String ATTRIBUTE = "kommons.usualLoginTimes";
+
+    private final UserModel user = mock(UserModel.class);
+
+    @Test
+    void readsTheEarliestAndLatestRecordedTime() {
+        recorded("09:15", "07:30", "17:45");
+
+        UnusualLoginTimeUserWrapper wrapper = new UnusualLoginTimeUserWrapper(user);
+
+        assertThat(wrapper.getMinTime()).isEqualTo(LocalTime.of(7, 30));
+        assertThat(wrapper.getMaxTime()).isEqualTo(LocalTime.of(17, 45));
+    }
+
+    @Test
+    void aSingleRecordedTimeIsBothMinimumAndMaximum() {
+        recorded("12:00");
+
+        UnusualLoginTimeUserWrapper wrapper = new UnusualLoginTimeUserWrapper(user);
+
+        assertThat(wrapper.getMinTime()).isEqualTo(LocalTime.NOON);
+        assertThat(wrapper.getMaxTime()).isEqualTo(LocalTime.NOON);
+    }
+
+    @Test
+    void withoutHistoryTheRangeSpansTheWholeDay() {
+        recorded();
+
+        UnusualLoginTimeUserWrapper wrapper = new UnusualLoginTimeUserWrapper(user);
+
+        assertThat(wrapper.hasRecordedLoginTimes()).isFalse();
+        assertThat(wrapper.getMinTime()).isEqualTo(LocalTime.MIN);
+        assertThat(wrapper.getMaxTime()).isEqualTo(LocalTime.MAX);
+    }
+
+    @Test
+    void historyIsReportedAsSoonAsThereIsOneEntry() {
+        recorded("08:00");
+
+        assertThat(new UnusualLoginTimeUserWrapper(user).hasRecordedLoginTimes()).isTrue();
+    }
+
+    @Test
+    void aNewLoginTimeIsPrepended() {
+        // Stored via ISO_LOCAL_TIME, which unlike LocalTime.toString() always writes the seconds.
+        recorded("08:00", "09:00");
+
+        new UnusualLoginTimeUserWrapper(user).addSuccessfulLoginTime(LocalTime.of(10, 30));
+
+        assertThat(storedTimes()).startsWith("10:30:00").hasSize(3);
+    }
+
+    @Test
+    void onlyTheFiveMostRecentLoginTimesAreKept() {
+        recorded("01:00", "02:00", "03:00", "04:00", "05:00");
+
+        new UnusualLoginTimeUserWrapper(user).addSuccessfulLoginTime(LocalTime.of(6, 0));
+
+        assertThat(storedTimes())
+            .hasSize(5)
+            .startsWith("06:00:00")
+            .doesNotContain("05:00");
+    }
+
+    @Test
+    void theFirstLoginTimeStartsTheHistory() {
+        recorded();
+
+        new UnusualLoginTimeUserWrapper(user).addSuccessfulLoginTime(LocalTime.of(6, 0));
+
+        assertThat(storedTimes()).containsExactly("06:00:00");
+    }
+
+    private void recorded(String... times) {
+        when(user.getAttributeStream(ATTRIBUTE)).thenAnswer(invocation -> Stream.of(times));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> storedTimes() {
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+        verify(user).setAttribute(eq(ATTRIBUTE), captor.capture());
+        return captor.getValue();
+    }
+}


### PR DESCRIPTION
Closes the coverage gap for one of the two providers that shipped without a single test. For a provider compiled against a moving Keycloak API, that is where silent breakage on an upgrade surfaces first.

**23 tests**: the usual login time bookkeeping, the range check including the wraparound across midnight and both of its boundaries, and the clock skew configuration.

## One defect found and fixed

A user with **no recorded login times** was flagged as logging in at an unusual time. An empty history falls back to a `MIN..MAX` range, and applying the skew to it wraps that range around midnight, so the whole middle of the day fell outside it. With the default skew of 15 minutes, every login between 00:15 and 23:45 matched the condition — i.e. every brand-new user, almost always.

Without a baseline no login can be unusual, so that case now returns early.

## Notes for review

- The range check was relaxed from `private` to package-private so it can be tested directly. Its caller reads the wall clock, so it cannot otherwise be pinned down.
- One test documents a deliberate choice: a non-numeric skew throws rather than silently falling back, because authenticating with a skew nobody configured is worse than failing.