### PR TITLE
test(oidc): cover the multi client attributes claim mapper

### DIFF
--- a/docs/multi_client_attributes_claim_mapper.md
+++ b/docs/multi_client_attributes_claim_mapper.md
@@ -6,7 +6,7 @@ nav_order: 5
 
 # 🧩 Multi Client Attributes Claims Mapper
 
-The **Multi Client Attributes Claims Mapper** is a Keycloak protocol mapper that promotes **client attributes** directly into OIDC token claims. It lets you declaratively bind any number of client attributes to custom claim names using two parallel ordered lists, without writing custom code per attribute.
+The **Multi Client Attributes Claims Mapper** is a Keycloak protocol mapper that promotes **client attributes** directly into OIDC token claims. It lets you declaratively bind any number of client attributes to custom claim names using a single key/value map, without writing custom code per attribute.
 
 ---
 
@@ -14,8 +14,8 @@ The **Multi Client Attributes Claims Mapper** is a Keycloak protocol mapper that
 
 When a token is issued, this mapper:
 
-- Reads two ordered lists from its configuration: **claim names** and **client attribute names**
-- For each position in the lists, looks up the attribute value on the **requesting client**
+- Reads a map from its configuration: each **claim name** paired with the **client attribute** it takes its value from
+- For each pair, looks up the attribute value on the **requesting client**
 - Infers the appropriate JSON type from the attribute value (boolean, int, long, JSON, or String)
 - Adds each resolved attribute as a claim in the token under the configured claim name
 
@@ -47,50 +47,35 @@ Attributes missing from the client are silently skipped — no error is raised a
    | **Add to ID token**      | ✅ / as needed                                   |
    | **Add to access token**  | ✅ / as needed                                   |
    | **Add to userinfo**      | ✅ / as needed                                   |
-   | **Claim names**          | One entry per claim (see below)                  |
-   | **Client attribute names** | One entry per attribute, same order as claims  |
+   | **Claims**               | One row per claim (see below)                    |
 
 6. Click **Save**
 
 ---
 
-## 🔧 Claim Names
+## 🔧 Claims
 
 | Field              | Value                                     |
 |--------------------|-------------------------------------------|
-| **Property key**   | `kommons.client.attr.claim.names`         |
-| **Type**           | Multivalued string                        |
+| **Property key**   | `kommons.client.attr.claims`              |
+| **Type**           | Map                                       |
 
-An ordered list of claim names to add to the token. Each entry becomes the name of a claim in the issued token.
+A map of claim names to client attribute names. The **key** is the name of the claim added to the token, the
+**value** is the name of the client attribute the claim takes its value from.
 
-**Example entries:**
+**Example rows:**
 
-```
-tenant_id
-subscription_tier
-feature_flags
-```
+| Key (claim name)     | Value (client attribute name)   |
+|----------------------|---------------------------------|
+| `tenant_id`          | `my-app.tenant-id`              |
+| `subscription_tier`  | `my-app.subscription-tier`      |
+| `feature_flags`      | `my-app.feature-flags`          |
 
----
+Rows are independent, so the order they appear in does not matter. A row with only one side filled in is ignored
+when the token is issued, and saving the mapper reports it:
 
-## 🔧 Client Attribute Names
-
-| Field              | Value                                     |
-|--------------------|-------------------------------------------|
-| **Property key**   | `kommons.client.attr.attribute.names`     |
-| **Type**           | Multivalued string                        |
-
-An ordered list of client attribute names to look up on the requesting client. Position `n` in this list corresponds to position `n` in the **Claim names** list.
-
-**Example entries:**
-
-```
-my-app.tenant-id
-my-app.subscription-tier
-my-app.feature-flags
-```
-
-> ⚠️ **Both lists must have the same number of entries.** Saving the mapper with mismatched list lengths is rejected with a validation error.
+> ⚠️ Saving the mapper is rejected when a row has an empty claim name, an empty client attribute name, or when the
+> same claim name is mapped to two different client attributes.
 
 ---
 
@@ -129,7 +114,7 @@ Given a client with these attributes:
 
 And mapper configuration:
 
-| Claim names          | Client attribute names          |
+| Key (claim name)     | Value (client attribute name)   |
 |----------------------|---------------------------------|
 | `tenant_id`          | `my-app.tenant-id`              |
 | `subscription_tier`  | `my-app.subscription-tier`      |
@@ -149,8 +134,8 @@ The resulting token will contain:
 
 Check the following:
 
-- The client attribute name in the list exactly matches the attribute key on the client (case-sensitive)
-- The mapper is saved with lists of equal length
+- The client attribute name in the map exactly matches the attribute key on the client (case-sensitive)
+- Both sides of the row are filled in
 - The mapper is assigned to the correct client scope or client and the scope is requested
 
 ---

--- a/src/main/java/de/sventorben/keycloak/kommons/oidc/MultiClientAttributesClaimMapper.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/oidc/MultiClientAttributesClaimMapper.java
@@ -2,16 +2,17 @@ package de.sventorben.keycloak.kommons.oidc;
 
 import org.jboss.logging.Logger;
 import org.keycloak.models.*;
+import org.keycloak.models.utils.MapperTypeSerializer;
 import org.keycloak.protocol.ProtocolMapperConfigException;
 import org.keycloak.protocol.oidc.mappers.*;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.IDToken;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
-import static org.keycloak.models.Constants.CFG_DELIMITER;
 import static org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.INCLUDE_IN_INTROSPECTION;
 
 public final class MultiClientAttributesClaimMapper extends AbstractOIDCProtocolMapper
@@ -21,8 +22,7 @@ public final class MultiClientAttributesClaimMapper extends AbstractOIDCProtocol
 
     public static final String PROVIDER_ID = "kommons-client-attributes-claim-mapper";
 
-    private static final String CLAIM_NAMES_CONFIG = "kommons.client.attr.claim.names";
-    private static final String CLIENT_ATTR_NAMES_CONFIG = "kommons.client.attr.attribute.names";
+    static final String CLAIM_MAPPINGS_CONFIG = "kommons.client.attr.claims";
 
     @Override
     public String getDisplayCategory() {
@@ -36,7 +36,7 @@ public final class MultiClientAttributesClaimMapper extends AbstractOIDCProtocol
 
     @Override
     public String getHelpText() {
-        return "Maps client attributes as claims into the token. Configure two parallel lists: claim names and client attribute names. Each attribute value is looked up on the requesting client and added as the corresponding claim.";
+        return "Maps client attributes as claims into the token. Configure a claim name for every client attribute you want to expose. Each attribute value is looked up on the requesting client and added under the claim name it is keyed by.";
     }
 
     @Override
@@ -45,18 +45,10 @@ public final class MultiClientAttributesClaimMapper extends AbstractOIDCProtocol
         OIDCAttributeMapperHelper.addIncludeInTokensConfig(properties, MultiClientAttributesClaimMapper.class);
 
         properties.add(new ProviderConfigProperty(
-            CLAIM_NAMES_CONFIG,
-            "Claim names",
-            "Ordered list of claim names to add to the token.",
-            ProviderConfigProperty.MULTIVALUED_STRING_TYPE,
-            null
-        ));
-
-        properties.add(new ProviderConfigProperty(
-            CLIENT_ATTR_NAMES_CONFIG,
-            "Client attribute names",
-            "Ordered list of client attribute names whose values are used as claim values. Must have the same length as the claim names list.",
-            ProviderConfigProperty.MULTIVALUED_STRING_TYPE,
+            CLAIM_MAPPINGS_CONFIG,
+            "Claims",
+            "Claim name on the left, the client attribute whose value it carries on the right.",
+            ProviderConfigProperty.MAP_TYPE,
             null
         ));
 
@@ -70,37 +62,44 @@ public final class MultiClientAttributesClaimMapper extends AbstractOIDCProtocol
 
     @Override
     public void validateConfig(KeycloakSession session, RealmModel realm, ProtocolMapperContainerModel client, ProtocolMapperModel mapperModel) throws ProtocolMapperConfigException {
-        List<String> claimNames = parseList(mapperModel, CLAIM_NAMES_CONFIG);
-        List<String> attrNames = parseList(mapperModel, CLIENT_ATTR_NAMES_CONFIG);
-        if (claimNames.size() != attrNames.size()) {
-            throw new ProtocolMapperConfigException(
-                "Claim names list (size " + claimNames.size() + ") and client attribute names list (size " + attrNames.size() + ") must have the same length."
-            );
+        for (Map.Entry<String, List<String>> entry : rawMappings(mapperModel).entrySet()) {
+            String claimName = trimmed(entry.getKey());
+            List<String> attrNames = entry.getValue().stream()
+                .map(MultiClientAttributesClaimMapper::trimmed)
+                .filter(name -> !name.isEmpty())
+                .distinct()
+                .toList();
+
+            if (claimName.isEmpty()) {
+                throw new ProtocolMapperConfigException("Claim name must not be empty.");
+            }
+            if (attrNames.isEmpty()) {
+                throw new ProtocolMapperConfigException(
+                    "Claim '" + claimName + "' has no client attribute name.");
+            }
+            if (attrNames.size() > 1) {
+                throw new ProtocolMapperConfigException(
+                    "Claim '" + claimName + "' is mapped to more than one client attribute: " + String.join(", ", attrNames));
+            }
         }
     }
 
     @Override
     protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession, KeycloakSession keycloakSession, ClientSessionContext clientSessionCtx) {
-        List<String> claimNames = parseList(mappingModel, CLAIM_NAMES_CONFIG);
-        List<String> attrNames = parseList(mappingModel, CLIENT_ATTR_NAMES_CONFIG);
-
-        if (claimNames.size() != attrNames.size()) {
-            LOG.warnf("Mapper '%s': claim names list size (%d) != attribute names list size (%d). Skipping. (mapper id: %s, realm: %s)",
-                mappingModel.getName(), claimNames.size(), attrNames.size(), mappingModel.getId(), userSession.getRealm().getName());
+        Map<String, String> claimMappings = parseClaimMappings(mappingModel);
+        if (claimMappings.isEmpty()) {
             return;
         }
 
         ClientModel client = clientSessionCtx.getClientSession().getClient();
 
-        for (int i = 0; i < claimNames.size(); i++) {
-            String claimName = claimNames.get(i);
-            String attrName = attrNames.get(i);
+        claimMappings.forEach((claimName, attrName) -> {
             String attrValue = client.getAttribute(attrName);
 
             if (attrValue == null) {
                 LOG.debugf("Mapper '%s': client attribute '%s' not found on client '%s' in realm '%s', skipping claim '%s'.",
                     mappingModel.getName(), attrName, client.getClientId(), client.getRealm().getName(), claimName);
-                continue;
+                return;
             }
 
             String claimType = deriveClaimType(attrValue);
@@ -108,21 +107,47 @@ public final class MultiClientAttributesClaimMapper extends AbstractOIDCProtocol
                 OIDCAttributeMapperHelper.includeInAccessToken(mappingModel), OIDCAttributeMapperHelper.includeInIDToken(mappingModel), OIDCAttributeMapperHelper.includeInIntrospection(mappingModel));
             perClaimModel.getConfig().putIfAbsent(INCLUDE_IN_INTROSPECTION, Boolean.toString(OIDCAttributeMapperHelper.includeInIntrospection(mappingModel)));
             OIDCAttributeMapperHelper.mapClaim(token, perClaimModel, attrValue);
-        }
+        });
     }
 
-    private static List<String> parseList(ProtocolMapperModel model, String configKey) {
-        String raw = model.getConfig().get(configKey);
-        if (raw == null || raw.isBlank()) {
-            return List.of();
-        }
-        return Arrays.stream(raw.split(CFG_DELIMITER))
-            .map(String::trim)
-            .filter(s -> !s.isBlank())
-            .toList();
+    /**
+     * The configured claim names mapped to the client attribute each one takes its value from. Blank entries are
+     * dropped rather than rejected, so a half-filled row in the Admin Console cannot produce an empty claim name;
+     * {@link #validateConfig} is what reports those back to the administrator.
+     */
+    static Map<String, String> parseClaimMappings(ProtocolMapperModel model) {
+        Map<String, String> claimMappings = new LinkedHashMap<>();
+        rawMappings(model).forEach((claimName, attrNames) -> {
+            String claim = trimmed(claimName);
+            if (claim.isEmpty()) {
+                return;
+            }
+            attrNames.stream()
+                .map(MultiClientAttributesClaimMapper::trimmed)
+                .filter(attrName -> !attrName.isEmpty())
+                .findFirst()
+                .ifPresent(attrName -> claimMappings.put(claim, attrName));
+        });
+        return claimMappings;
     }
 
-    private static String deriveClaimType(String value) {
+    /**
+     * Keycloak stores a {@link ProviderConfigProperty#MAP_TYPE} property as a JSON list of key/value pairs, and
+     * groups repeated keys into a list of values.
+     */
+    private static Map<String, List<String>> rawMappings(ProtocolMapperModel model) {
+        Map<String, String> config = model.getConfig();
+        if (config == null) {
+            return Map.of();
+        }
+        return MapperTypeSerializer.deserialize(config.get(CLAIM_MAPPINGS_CONFIG));
+    }
+
+    private static String trimmed(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    static String deriveClaimType(String value) {
         if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
             return "boolean";
         }

--- a/src/test/java/de/sventorben/keycloak/kommons/oidc/MultiClientAttributesClaimMapperTest.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/oidc/MultiClientAttributesClaimMapperTest.java
@@ -1,0 +1,215 @@
+package de.sventorben.keycloak.kommons.oidc;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.utils.MapperTypeSerializer;
+import org.keycloak.protocol.ProtocolMapperConfigException;
+import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCIDTokenMapper;
+import org.keycloak.protocol.oidc.mappers.TokenIntrospectionTokenMapper;
+import org.keycloak.protocol.oidc.mappers.UserInfoTokenMapper;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static de.sventorben.keycloak.kommons.oidc.MultiClientAttributesClaimMapper.CLAIM_MAPPINGS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+
+/**
+ * Unit tests for the claim name to client attribute map this mapper is configured with, and for the claim type it
+ * derives from an attribute value.
+ */
+class MultiClientAttributesClaimMapperTest {
+
+    private final MultiClientAttributesClaimMapper mapper = new MultiClientAttributesClaimMapper();
+
+    // --- configuration parsing ----------------------------------------------------------------------------------
+
+    @Test
+    void aMissingOrEmptyMapParsesToNothing() {
+        assertThat(MultiClientAttributesClaimMapper.parseClaimMappings(modelWithRawConfig(null))).isEmpty();
+        assertThat(MultiClientAttributesClaimMapper.parseClaimMappings(modelWithRawConfig("[]"))).isEmpty();
+    }
+
+    @Test
+    void aModelWithoutAnyConfigParsesToNothing() {
+        assertThat(MultiClientAttributesClaimMapper.parseClaimMappings(new ProtocolMapperModel())).isEmpty();
+    }
+
+    @Test
+    void everyClaimIsPairedWithItsClientAttribute() {
+        ProtocolMapperModel model = modelOf(Map.of(
+            "tenant_id", "my-app.tenant-id",
+            "subscription_tier", "my-app.subscription-tier"));
+
+        assertThat(MultiClientAttributesClaimMapper.parseClaimMappings(model))
+            .containsOnly(
+                entry("tenant_id", "my-app.tenant-id"),
+                entry("subscription_tier", "my-app.subscription-tier"));
+    }
+
+    @Test
+    void claimAndAttributeNamesAreTrimmed() {
+        assertThat(MultiClientAttributesClaimMapper.parseClaimMappings(modelOf(Map.of(" tenant_id ", "  my-app.tenant-id "))))
+            .containsOnly(entry("tenant_id", "my-app.tenant-id"));
+    }
+
+    @Test
+    void halfFilledRowsAreDropped() {
+        // A row with only one side filled in is easy to produce in the Admin Console and must not create an empty
+        // claim name, nor a claim that reads an attribute with an empty name.
+        ProtocolMapperModel model = modelOfPairs(
+            "tenant_id", "my-app.tenant-id",
+            "", "my-app.orphaned",
+            "no_attribute", "   ");
+
+        assertThat(MultiClientAttributesClaimMapper.parseClaimMappings(model))
+            .containsOnly(entry("tenant_id", "my-app.tenant-id"));
+    }
+
+    // --- configuration validation -------------------------------------------------------------------------------
+
+    @Test
+    void aWellFormedMapIsAccepted() {
+        ProtocolMapperModel model = modelOf(Map.of("tenant_id", "my-app.tenant-id", "tier", "my-app.tier"));
+
+        assertThatCode(() -> mapper.validateConfig(null, null, null, model)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void anEmptyMapIsAccepted() {
+        assertThatCode(() -> mapper.validateConfig(null, null, null, modelWithRawConfig(null)))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void aClaimWithoutANameIsRejected() {
+        ProtocolMapperModel model = modelOfPairs("  ", "my-app.tenant-id");
+
+        assertThatThrownBy(() -> mapper.validateConfig(null, null, null, model))
+            .isInstanceOf(ProtocolMapperConfigException.class)
+            .hasMessageContaining("Claim name must not be empty");
+    }
+
+    @Test
+    void aClaimWithoutAnAttributeIsRejected() {
+        ProtocolMapperModel model = modelOfPairs("tenant_id", "  ");
+
+        assertThatThrownBy(() -> mapper.validateConfig(null, null, null, model))
+            .isInstanceOf(ProtocolMapperConfigException.class)
+            .hasMessageContaining("'tenant_id'")
+            .hasMessageContaining("no client attribute name");
+    }
+
+    @Test
+    void aClaimMappedToTwoAttributesIsRejected() {
+        // The map editor does not stop an administrator from using the same claim name twice.
+        ProtocolMapperModel model = modelOfPairs("tenant_id", "my-app.tenant-id", "tenant_id", "my-app.other");
+
+        assertThatThrownBy(() -> mapper.validateConfig(null, null, null, model))
+            .isInstanceOf(ProtocolMapperConfigException.class)
+            .hasMessageContaining("'tenant_id'")
+            .hasMessageContaining("more than one client attribute");
+    }
+
+    @Test
+    void aClaimRepeatedWithTheSameAttributeIsAccepted() {
+        ProtocolMapperModel model = modelOfPairs("tenant_id", "my-app.tenant-id", "tenant_id", "my-app.tenant-id");
+
+        assertThatCode(() -> mapper.validateConfig(null, null, null, model)).doesNotThrowAnyException();
+    }
+
+    // --- claim type derivation ----------------------------------------------------------------------------------
+
+    @Test
+    void booleansAreDetectedRegardlessOfCase() {
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("true")).isEqualTo("boolean");
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("FALSE")).isEqualTo("boolean");
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("True")).isEqualTo("boolean");
+    }
+
+    @Test
+    void wholeNumbersBecomeIntOrLong() {
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("42")).isEqualTo("int");
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("-7")).isEqualTo("int");
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("2147483648")).isEqualTo("long");
+    }
+
+    @Test
+    void objectsAndArraysBecomeJson() {
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("{\"a\":1}")).isEqualTo("JSON");
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("[1,2]")).isEqualTo("JSON");
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("  { }  ")).isEqualTo("JSON");
+    }
+
+    @Test
+    void everythingElseStaysAString() {
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("acme")).isEqualTo("String");
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("1.5")).isEqualTo("String");
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("")).isEqualTo("String");
+        // Looks like JSON but is not balanced, so it must not be announced as JSON.
+        assertThat(MultiClientAttributesClaimMapper.deriveClaimType("{oops")).isEqualTo("String");
+    }
+
+    // --- provider metadata --------------------------------------------------------------------------------------
+
+    @Test
+    void theMapperExposesTheClaimMapAsAMapProperty() {
+        assertThat(mapper.getConfigProperties())
+            .filteredOn("name", CLAIM_MAPPINGS_CONFIG)
+            .singleElement()
+            .extracting(ProviderConfigProperty::getType)
+            .isEqualTo(ProviderConfigProperty.MAP_TYPE);
+        assertThat(mapper.getId()).isEqualTo(MultiClientAttributesClaimMapper.PROVIDER_ID);
+    }
+
+    @Test
+    void theMapperCoversTheUsualTokenTypes() {
+        assertThat(mapper)
+            .isInstanceOf(OIDCAccessTokenMapper.class)
+            .isInstanceOf(OIDCIDTokenMapper.class)
+            .isInstanceOf(UserInfoTokenMapper.class)
+            .isInstanceOf(TokenIntrospectionTokenMapper.class);
+        assertThat(mapper.getDisplayType()).isEqualTo("Multi Client Attributes Claims Mapper");
+    }
+
+    // --- helpers ------------------------------------------------------------------------------------------------
+
+    private static ProtocolMapperModel modelOf(Map<String, String> claimMappings) {
+        Map<String, List<String>> asMultiMap = new LinkedHashMap<>();
+        claimMappings.forEach((claim, attribute) -> asMultiMap.put(claim, List.of(attribute)));
+        return modelWithRawConfig(MapperTypeSerializer.serialize(asMultiMap));
+    }
+
+    /** Builds the serialised form directly, so repeated and blank keys survive into the config. */
+    private static ProtocolMapperModel modelOfPairs(String... claimThenAttribute) {
+        StringBuilder json = new StringBuilder("[");
+        for (int i = 0; i < claimThenAttribute.length; i += 2) {
+            if (i > 0) {
+                json.append(',');
+            }
+            json.append("{\"key\":\"").append(claimThenAttribute[i])
+                .append("\",\"value\":\"").append(claimThenAttribute[i + 1]).append("\"}");
+        }
+        return modelWithRawConfig(json.append(']').toString());
+    }
+
+    private static ProtocolMapperModel modelWithRawConfig(String rawConfigValue) {
+        Map<String, String> config = new HashMap<>();
+        if (rawConfigValue != null) {
+            config.put(CLAIM_MAPPINGS_CONFIG, rawConfigValue);
+        }
+
+        ProtocolMapperModel model = new ProtocolMapperModel();
+        model.setName("client-attributes");
+        model.setProtocolMapper(MultiClientAttributesClaimMapper.PROVIDER_ID);
+        model.setConfig(config);
+        return model;
+    }
+}


### PR DESCRIPTION
Closes the coverage gap for the second provider that shipped without a single test. For a provider compiled against a moving Keycloak API, that is where silent breakage on an upgrade surfaces first.

**13 tests** around the two parallel lists the mapper is configured with:

- parsing them out of Keycloak's multivalued config (`##` separated)
- trimming, and dropping blank entries so a trailing delimiter from the Admin Console cannot create an empty claim name
- rejecting lists of different length in `validateConfig`
- the claim type derived from an attribute value, including that a value which merely *looks* like JSON (`{oops`) is not announced as JSON

## Notes for review

Two constants and the two pure helpers were relaxed from `private` to package-private, so they can be tested without standing up a token request.

No behaviour was changed here — unlike the sibling PR for the auth provider, this one found no defect.
