### PR TITLE
feat(ldap): expose the JNDI connection pool state as metrics

### DIFF
--- a/docker-compose.ldap-metrics.yml
+++ b/docker-compose.ldap-metrics.yml
@@ -1,0 +1,67 @@
+# Playground for the LDAP connection pool metrics.
+#
+#   mvn package -DskipTests
+#   docker compose -f docker-compose.ldap-metrics.yml up
+#
+#   Keycloak   http://localhost:8081        (admin / admin), realm "ldap-metrics"
+#   Metrics    http://localhost:9001/metrics
+#   LDAP       ldap://localhost:1389        (cn=admin,dc=example,dc=org / adminpassword)
+#              users live under ou=users,dc=example,dc=org
+#
+# Ports are deliberately shifted so this can run next to the regular docker-compose.yml.
+#
+#   curl -s http://localhost:9001/metrics | grep keycloak_ldap_pool
+#
+# keycloak_ldap_pool_accessible must be 1. If it is 0 the --add-exports below did not take effect,
+# or the JDK output could not be parsed; either way the other pool gauges are not to be trusted.
+services:
+
+  ldap:
+    container_name: kommons-ldap
+    image: osixia/openldap:1.5.0
+    command: ["--copy-service"]
+    environment:
+      LDAP_ORGANISATION: Kommons
+      LDAP_DOMAIN: example.org
+      LDAP_ADMIN_PASSWORD: adminpassword
+    # Seeds ou=users,dc=example,dc=org with a few inetOrgPerson entries to federate.
+    volumes:
+      - ./tools/ldap-seed.ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom/seed.ldif:ro
+    ports:
+      - 1389:389
+
+  keycloak:
+    container_name: kommons-keycloak-ldap-metrics
+    hostname: keycloak
+    image: quay.io/keycloak/keycloak:26.7.0
+    depends_on:
+      - ldap
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+
+      # LdapPoolManager.showStats is public but its package is not exported, so it needs exporting.
+      # --add-exports is enough; --add-opens would grant deep reflection we do not use.
+      # The JNDI pool settings are process wide and are read once, when LdapPoolManager initialises.
+      JAVA_OPTS_APPEND: >-
+        --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
+        -Dcom.sun.jndi.ldap.connect.pool.maxsize=20
+        -Dcom.sun.jndi.ldap.connect.pool.prefsize=5
+        -Dcom.sun.jndi.ldap.connect.pool.initsize=1
+        -Dcom.sun.jndi.ldap.connect.pool.timeout=300000
+        -Dcom.sun.jndi.ldap.connect.pool.debug=fine
+    command:
+      - start-dev
+      - --metrics-enabled=true
+      - --health-enabled=true
+      # Keycloak 26 uses the double dash separator between SPI, provider and property.
+      - --spi-events-listener--kommons-ldap-pool-metrics--enabled=true
+      # Brings the realm "ldap-metrics" with a ready-made LDAP federation, so the pool can be
+      # exercised without clicking anything together first.
+      - --import-realm
+    ports:
+      - 8081:8080
+      - 9001:9000
+    volumes:
+      - ./target/kommons.jar:/opt/keycloak/providers/kommons.jar
+      - ./tools/ldap-metrics-realm:/opt/keycloak/data/import:ro

--- a/docs/developer_info.md
+++ b/docs/developer_info.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Notice for Developers
-nav_order: 7
+nav_order: 8
 ---
 
 # Notice for Developers

--- a/docs/ldap_pool_metrics.md
+++ b/docs/ldap_pool_metrics.md
@@ -1,0 +1,166 @@
+---
+layout: default
+title: LDAP Connection Pool Metrics
+nav_order: 7
+---
+
+# 🔌 LDAP Connection Pool Metrics
+
+Exposes the state of the JVM-global JNDI connection pool that Keycloak's LDAP user federation uses, as
+`keycloak_ldap_pool_*` gauges on Keycloak's `/metrics` endpoint.
+
+Answers the questions the built-in metrics do not: *how many LDAP connections are open right now, how many are
+idle, am I about to hit the pool limit?*
+
+---
+
+## ⚠️ Read this before enabling
+
+{: .warning }
+> **Keycloak has its own LDAP metrics, and for most deployments they are the better answer.**
+> Since 26.x Keycloak ships a `keycloak_ldap_requests_*` timer covering request counts, latency and errors —
+> enable it with `--features=ldap-metrics`. It costs no extra dependency and no JVM flags.
+>
+> This extension covers only what that timer does not: **pool occupancy**. If you do not specifically need to see
+> idle/busy connections, use the built-in feature instead.
+
+This provider reads JDK internals. That is a deliberate trade-off, spelled out under
+[What this costs you](#-what-this-costs-you) — read it before putting this in production.
+
+---
+
+## 📊 Exposed metrics
+
+| Metric | Meaning |
+|---|---|
+| `keycloak_ldap_pool_accessible` | `1` if the numbers could be read **and parsed**, `0` otherwise |
+| `keycloak_ldap_pool_max_size` | Configured maximum connections per identity pool (`0` = unlimited) |
+| `keycloak_ldap_pool_preferred_size` | Configured preferred number of connections |
+| `keycloak_ldap_pool_init_size` | Configured initial number of connections |
+| `keycloak_ldap_pool_timeout_milliseconds` | Idle timeout before a pooled connection is closed (`0` = none) |
+| `keycloak_ldap_pool_identity_pools{authentication}` | Number of distinct host/port/principal groups |
+| `keycloak_ldap_pool_connections{authentication,state}` | Connection counts, `state` in `total`/`idle`/`busy`/`expired` |
+
+`authentication` is `none`, `simple` or `digest-md5` — the JDK keeps one pool per mechanism. A mechanism that is
+not enabled never appears in the JDK's output and is reported as all zeros.
+
+The four configuration gauges echo the JVM-wide `com.sun.jndi.ldap.connect.pool.*` system properties, **not**
+per-provider settings. They are useful to confirm what the JVM actually picked up.
+
+> 💡 **`keycloak_ldap_pool_accessible` is the gauge to alert on.** If it is `0`, every other value here is
+> meaningless — either the JVM flag is missing or the JDK output could no longer be parsed. The provider
+> deliberately reports `0` rather than inventing zeros.
+
+---
+
+## 🚀 Setup
+
+### 1. JVM option
+
+```
+--add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED
+```
+
+For example via `JAVA_OPTS_APPEND`. Without it `keycloak_ldap_pool_accessible` is `0` and nothing else is
+populated.
+
+`--add-exports` is deliberately the weaker option: the provider only invokes a *public* method, so the deep
+reflection that `--add-opens` grants is not needed.
+
+### 2. Enable the provider
+
+It is opt-in, because of the JDK coupling:
+
+```
+--metrics-enabled=true
+--spi-events-listener--kommons-ldap-pool-metrics--enabled=true
+```
+
+> ⚠️ Note the **double dashes** between SPI, provider and property. Keycloak 26 changed this format; the old
+> single-dash spelling is not picked up.
+
+The provider is registered as an event listener purely to get a startup hook — Keycloak initialises every enabled
+provider factory at boot. You do **not** need to enable it as an event listener in any realm, and it never handles
+an event.
+
+### 3. Connection pooling must be on
+
+Pool metrics only show something if Keycloak actually pools. Set **Connection pooling** on the LDAP user
+federation provider (`connectionPooling = true`). Without it the JDK never creates a pool and all counters stay
+at `0` while `accessible` remains `1`.
+
+### 4. Scrape
+
+```bash
+curl -s http://<host>:9000/metrics | grep keycloak_ldap_pool
+```
+
+---
+
+## 🧪 Try it out
+
+The repository ships a ready-made playground:
+
+```bash
+mvn package -DskipTests
+docker compose -p kommons-ldap -f docker-compose.ldap-metrics.yml up
+```
+
+It starts an OpenLDAP with two users and a Keycloak whose realm `ldap-metrics` already contains a matching LDAP
+federation, on shifted ports so it can run next to the regular `docker-compose.yml`:
+
+| | |
+|---|---|
+| Keycloak | <http://localhost:8081> (`admin` / `admin`), realm `ldap-metrics` |
+| Metrics | <http://localhost:9001/metrics> |
+| LDAP | `ldap://localhost:1389`, `cn=admin,dc=example,dc=org` / `adminpassword` |
+
+Searching a federated user drives traffic through the pool:
+
+```bash
+# after an admin-cli token, search the federated realm
+curl -s ".../admin/realms/ldap-metrics/users?search=alice" -H "Authorization: Bearer $TOKEN"
+
+curl -s http://localhost:9001/metrics | grep keycloak_ldap_pool_connections
+# keycloak_ldap_pool_connections{authentication="simple",state="idle"}  1.0
+# keycloak_ldap_pool_connections{authentication="simple",state="total"} 1.0
+```
+
+Each search that cannot reuse a connection adds one, and connections return to the pool as `idle` when the
+operation completes.
+
+---
+
+## 💸 What this costs you
+
+Being explicit, because this is not an ordinary extension:
+
+**It depends on a non-exported JDK package.** `com.sun.jndi.ldap.LdapPoolManager#showStats(PrintStream)` is
+`public`, but its package is not exported and therefore outside any compatibility promise. That is the whole
+reason the JVM flag is needed.
+
+**It parses a debug dump, not an API.** The output is meant for humans. A future JDK can change it in a patch
+release without deprecation and without a compile error. The provider defends against this as far as it can: if
+not a single pool section is recognised, it reports `accessible = 0` instead of a plausible-looking wall of
+zeros. Subtler changes — a renamed counter, a changed unit — would not be caught.
+
+**It does not work in a native image.** Keycloak's GraalVM-based distribution cannot do this reflection.
+
+**It reads under a lock.** `showStats` synchronises on the pool map while iterating, on a path that real LDAP
+requests also take. A snapshot is memoized for two seconds so a scrape costs one pass regardless of how many
+gauges are exposed, but the contention is not zero.
+
+In exchange you get numbers that are otherwise not obtainable at all. Whether that trade is worth it depends on
+whether pool occupancy is something you actually act on.
+
+---
+
+## 🩺 Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| No `keycloak_ldap_pool_*` metrics at all | Provider not enabled, or `--metrics-enabled=true` missing. Check the startup log for `Registered LDAP connection pool metrics` |
+| `keycloak_ldap_pool_accessible 0` | `--add-exports` missing, or the JDK output could not be parsed. The log names which |
+| `accessible 1`, all counters `0` | Nothing has been pooled yet. Either no LDAP traffic, or **Connection pooling** is off on the federation provider |
+| Counters stay `0` although users are found | Confirm the federation provider really is consulted. A provider whose `parentId` does not match the realm id is stored but never used |
+| `NoSuchMethodError` on `strongReference` | Micrometer older than the one Keycloak ships. Verified against 1.16.3 in Keycloak 26.7 |

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,10 @@
         <!-- For compatibility tests -->
         <keycloak.version>${version.keycloak}</keycloak.version>
 
+        <!-- Provided by the Keycloak distribution (lib/main/io.micrometer.micrometer-core-*.jar),
+             which Quarkus binds to the /metrics endpoint. Compile-time only; never bundled. -->
+        <version.micrometer>1.16.3</version.micrometer>
+
         <version.mockito>5.23.0</version.mockito>
         <version.testcontainers>1.21.4</version.testcontainers>
     </properties>
@@ -233,6 +237,12 @@ Signed-off-by: GitHub Actions &lt;actions@github.com&gt;</scmDevelopmentCommitCo
                     <artifactId>slf4j-jboss-logmanager</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>${version.micrometer}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test -->

--- a/src/main/java/de/sventorben/keycloak/kommons/ldap/AuthMechanism.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/ldap/AuthMechanism.java
@@ -1,0 +1,53 @@
+package de.sventorben.keycloak.kommons.ldap;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * The LDAP authentication mechanisms that {@code com.sun.jndi.ldap.LdapPoolManager} keeps separate
+ * connection pools for.
+ *
+ * <p>Each constant knows both how the JDK dump names its section ({@code "anonymous pools:"},
+ * {@code "simple auth pools:"}, {@code "DIGEST-MD5 auth pools:"}) and the value used for the
+ * {@code authentication} metric tag, so the two never drift apart.
+ */
+enum AuthMechanism {
+
+    /** Unauthenticated connections; the dump calls these "anonymous". */
+    NONE("none", "anonymous"),
+    SIMPLE("simple", "simple"),
+    DIGEST_MD5("digest-md5", "digest");
+
+    /** The dump ends every section header with this, which is what makes a line a header at all. */
+    private static final String SECTION_SUFFIX = "pools:";
+
+    private final String label;
+    private final String headerToken;
+
+    AuthMechanism(String label, String headerToken) {
+        this.label = label;
+        this.headerToken = headerToken;
+    }
+
+    /** The value of the {@code authentication} tag on the exported metrics. */
+    String label() {
+        return label;
+    }
+
+    /**
+     * Recognises a section header such as {@code "simple auth pools:"}. Returns empty when the line
+     * does not open a section, which is what tells the parser that the dump format has changed.
+     */
+    static Optional<AuthMechanism> ofSectionHeader(String line) {
+        if (!line.endsWith(SECTION_SUFFIX)) {
+            return Optional.empty();
+        }
+        String lower = line.toLowerCase(Locale.ROOT);
+        for (AuthMechanism mechanism : values()) {
+            if (lower.contains(mechanism.headerToken)) {
+                return Optional.of(mechanism);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/ldap/AuthPoolStats.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/ldap/AuthPoolStats.java
@@ -1,0 +1,21 @@
+package de.sventorben.keycloak.kommons.ldap;
+
+/**
+ * Aggregated connection counts for a single JNDI/LDAP authentication pool
+ * ({@code none}, {@code simple} or {@code digest-md5}), summed across all of that pool's
+ * distinct connection-identity groups (host/port/principal combinations).
+ *
+ * @param identityPools number of distinct connection-identity groups currently held
+ * @param total         total number of pooled connections
+ * @param idle          connections that are idle and available for reuse
+ * @param busy          connections that are currently in use
+ * @param expired       connections that have expired but are not yet removed
+ */
+record AuthPoolStats(int identityPools, int total, int idle, int busy, int expired) {
+
+    private static final AuthPoolStats EMPTY = new AuthPoolStats(0, 0, 0, 0, 0);
+
+    static AuthPoolStats empty() {
+        return EMPTY;
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/ldap/ConnectionState.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/ldap/ConnectionState.java
@@ -1,0 +1,36 @@
+package de.sventorben.keycloak.kommons.ldap;
+
+import java.util.function.ToIntFunction;
+
+/**
+ * The states a pooled LDAP connection is counted in, as reported per connection identity in the
+ * JDK dump and exported as the {@code state} tag of {@code keycloak_ldap_pool_connections}.
+ *
+ * <p>{@link #TOTAL} is the whole of a pool rather than a peer of the others: a connection is idle,
+ * busy or expired, and all three are included in the total.
+ */
+enum ConnectionState {
+
+    TOTAL("total", AuthPoolStats::total),
+    IDLE("idle", AuthPoolStats::idle),
+    BUSY("busy", AuthPoolStats::busy),
+    EXPIRED("expired", AuthPoolStats::expired);
+
+    private final String label;
+    private final ToIntFunction<AuthPoolStats> count;
+
+    ConnectionState(String label, ToIntFunction<AuthPoolStats> count) {
+        this.label = label;
+        this.count = count;
+    }
+
+    /** The value of the {@code state} tag on the exported metric. */
+    String label() {
+        return label;
+    }
+
+    /** The number of connections in this state within the given pool. */
+    int countIn(AuthPoolStats stats) {
+        return count.applyAsInt(stats);
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapConnectionPoolIntrospector.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapConnectionPoolIntrospector.java
@@ -6,8 +6,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 /**
  * Reads live statistics from the JVM-global JNDI/LDAP connection pool managed by
@@ -41,6 +39,8 @@ import java.util.Map;
  * ***** end *****
  * </pre>
  *
+ * <p>Reading that text is {@link PoolDumpParser}'s job; this class only obtains it.
+ *
  * <p>{@code showStats} is public, but its package is not exported, so the call needs:
  * <pre>
  *   --add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED
@@ -56,10 +56,6 @@ import java.util.Map;
 final class LdapConnectionPoolIntrospector {
 
     private static final Logger LOG = Logger.getLogger(LdapConnectionPoolIntrospector.class);
-
-    private static final String AUTH_NONE = "none";
-    private static final String AUTH_SIMPLE = "simple";
-    private static final String AUTH_DIGEST = "digest-md5";
 
     private final Method showStats;
     private final boolean available;
@@ -92,7 +88,7 @@ final class LdapConnectionPoolIntrospector {
             return LdapPoolSnapshot.unavailable();
         }
         try {
-            return parse(dumpStats());
+            return PoolDumpParser.parse(dumpStats());
         } catch (Throwable t) {
             if (!loggedReadFailure) {
                 loggedReadFailure = true;
@@ -112,162 +108,5 @@ final class LdapConnectionPoolIntrospector {
             showStats.invoke(null, out);
         }
         return buffer.toString(StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Turns the dump into a snapshot. The size lines appear twice, once for the manager and once
-     * inside every pool section; only the leading ones are the configured values, so parsing stops
-     * looking for them as soon as the first section starts.
-     */
-    static LdapPoolSnapshot parse(String stats) {
-        DumpReader reader = new DumpReader();
-        for (String line : stats.split("\\R")) {
-            reader.accept(line.trim());
-        }
-        return reader.snapshot();
-    }
-
-    /**
-     * Consumes the dump line by line. Lines before the first section carry the manager's configured
-     * sizes; from the first section header on, every line belongs to the section currently open.
-     */
-    private static final class DumpReader {
-
-        private final Map<String, AuthPoolStats> byAuth = new LinkedHashMap<>();
-
-        private long idleTimeout;
-        private int maxSize;
-        private int prefSize;
-        private int initSize;
-
-        private String auth;
-        private PoolSection section;
-
-        DumpReader() {
-            byAuth.put(AUTH_NONE, AuthPoolStats.empty());
-            byAuth.put(AUTH_SIMPLE, AuthPoolStats.empty());
-            byAuth.put(AUTH_DIGEST, AuthPoolStats.empty());
-        }
-
-        void accept(String line) {
-            String next = sectionOf(line);
-            if (next != null) {
-                closeSection();
-                auth = next;
-                section = new PoolSection();
-            } else if (section == null) {
-                readConfiguration(line);
-            } else {
-                section.accept(line);
-            }
-        }
-
-        private void readConfiguration(String line) {
-            idleTimeout = labelled(line, "idle timeout:", idleTimeout);
-            maxSize = (int) labelled(line, "maximum pool size:", maxSize);
-            prefSize = (int) labelled(line, "preferred pool size:", prefSize);
-            initSize = (int) labelled(line, "initial pool size:", initSize);
-        }
-
-        private void closeSection() {
-            if (auth != null) {
-                byAuth.put(auth, section.toStats());
-            }
-        }
-
-        LdapPoolSnapshot snapshot() {
-            closeSection();
-            if (auth == null) {
-                // Not a single "<mechanism> pools:" section: the format is not what we expect, so the
-                // zeros would be made up rather than measured.
-                return LdapPoolSnapshot.unavailable();
-            }
-            return new LdapPoolSnapshot(true, idleTimeout, maxSize, prefSize, initSize, byAuth);
-        }
-    }
-
-    /** The running totals of the one pool section currently being read. */
-    private static final class PoolSection {
-
-        private int identityPools;
-        private int total;
-        private int idle;
-        private int busy;
-        private int expired;
-
-        void accept(String line) {
-            if (line.startsWith("current pool size:")) {
-                identityPools = (int) labelled(line, "current pool size:", identityPools);
-            } else if (line.contains("size=")) {
-                total += extract(line, "size=");
-                busy += extract(line, "busy=");
-                idle += extract(line, "idle=");
-                expired += extract(line, "expired=");
-            }
-        }
-
-        AuthPoolStats toStats() {
-            return new AuthPoolStats(identityPools, total, idle, busy, expired);
-        }
-    }
-
-    /**
-     * Maps a section header such as {@code "simple auth pools:"} to an authentication label, or
-     * returns {@code null} when the line does not start a section.
-     */
-    private static String sectionOf(String line) {
-        if (!line.endsWith("pools:")) {
-            return null;
-        }
-        String lower = line.toLowerCase(java.util.Locale.ROOT);
-        if (lower.startsWith("anonymous")) {
-            return AUTH_NONE;
-        }
-        if (lower.startsWith("simple")) {
-            return AUTH_SIMPLE;
-        }
-        if (lower.contains("digest")) {
-            return AUTH_DIGEST;
-        }
-        return null;
-    }
-
-    /** Reads the number behind {@code label}, or keeps {@code fallback} when the line does not match. */
-    private static long labelled(String line, String label, long fallback) {
-        if (!line.startsWith(label)) {
-            return fallback;
-        }
-        try {
-            return Long.parseLong(line.substring(label.length()).trim());
-        } catch (NumberFormatException e) {
-            return fallback;
-        }
-    }
-
-    /**
-     * Extracts the integer value that follows {@code key} in a per-identity line such as
-     * {@code "host:389:::null:cn=admin:size=10; use=45; busy=2; idle=7; expired=1"}. Returns 0 when
-     * the key is absent or the value cannot be parsed.
-     */
-    static int extract(String stats, String key) {
-        int start = stats.indexOf(key);
-        if (start < 0) {
-            return 0;
-        }
-        start += key.length();
-        int end = start;
-        while (end < stats.length() && isNumberChar(stats.charAt(end))) {
-            end++;
-        }
-        try {
-            return Integer.parseInt(stats.substring(start, end));
-        } catch (NumberFormatException e) {
-            return 0;
-        }
-    }
-
-    /** ASCII digits and a leading minus; the dump never uses grouping separators or decimals. */
-    private static boolean isNumberChar(char c) {
-        return c == '-' || (c >= '0' && c <= '9');
     }
 }

--- a/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapConnectionPoolIntrospector.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapConnectionPoolIntrospector.java
@@ -1,0 +1,273 @@
+package de.sventorben.keycloak.kommons.ldap;
+
+import org.jboss.logging.Logger;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Reads live statistics from the JVM-global JNDI/LDAP connection pool managed by
+ * {@code com.sun.jndi.ldap.LdapPoolManager}. Keycloak's LDAP user federation uses JNDI with
+ * connection pooling enabled, but the JDK exposes no public API for these numbers.
+ *
+ * <p>It does however have a {@code public static void showStats(PrintStream)} that dumps the whole
+ * pool state in one go, so a single reflective call is enough &mdash; no digging through
+ * {@code Pool}, {@code ConnectionsRef} and {@code Connections} internals. Its output looks like:
+ *
+ * <pre>
+ * ***** start *****
+ * idle timeout: 300000
+ * maximum pool size: 20
+ * preferred pool size: 5
+ * initial pool size: 1
+ * protocol types: plain
+ * authentication types: none simple
+ * anonymous pools:
+ * ===== Pool start ======================
+ * maximum pool size: 20
+ * ...
+ * current pool size: 0
+ * ====== Pool end =====================
+ * simple auth pools:
+ * ===== Pool start ======================
+ * ...
+ * current pool size: 1
+ *    localhost:389:::null:cn=admin,dc=example,dc=org:size=2; use=2; busy=2; idle=0; expired=0
+ * ====== Pool end =====================
+ * ***** end *****
+ * </pre>
+ *
+ * <p>{@code showStats} is public, but its package is not exported, so the call needs:
+ * <pre>
+ *   --add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED
+ * </pre>
+ * The weaker {@code --add-exports} is deliberate: we only invoke a public member, so the deep
+ * reflection that {@code --add-opens} grants is not required.
+ *
+ * <p>When the option is missing, or the JDK output changes shape so that not a single pool section
+ * is recognised, {@link LdapPoolSnapshot#accessible()} is {@code false}. That matters: the metric
+ * derived from it is the signal that the numbers can be trusted, so silently reporting zeros
+ * against an unparseable dump would be worse than reporting nothing.
+ */
+final class LdapConnectionPoolIntrospector {
+
+    private static final Logger LOG = Logger.getLogger(LdapConnectionPoolIntrospector.class);
+
+    private static final String AUTH_NONE = "none";
+    private static final String AUTH_SIMPLE = "simple";
+    private static final String AUTH_DIGEST = "digest-md5";
+
+    private final Method showStats;
+    private final boolean available;
+
+    private volatile boolean loggedReadFailure;
+
+    LdapConnectionPoolIntrospector() {
+        Method method = null;
+        try {
+            // initialize=false: don't run the class' static initializer while merely probing access.
+            Class<?> poolManager = Class.forName("com.sun.jndi.ldap.LdapPoolManager", false,
+                LdapConnectionPoolIntrospector.class.getClassLoader());
+            method = poolManager.getMethod("showStats", PrintStream.class);
+        } catch (Throwable t) {
+            LOG.warnf("LDAP connection pool metrics are unavailable: cannot access JDK internals (%s). "
+                + "Add the JVM option '--add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED' to enable them. "
+                + "The keycloak_ldap_pool_accessible metric will report 0.", t.toString());
+        }
+
+        this.showStats = method;
+        this.available = method != null;
+    }
+
+    boolean isAvailable() {
+        return available;
+    }
+
+    LdapPoolSnapshot snapshot() {
+        if (!available) {
+            return LdapPoolSnapshot.unavailable();
+        }
+        try {
+            return parse(dumpStats());
+        } catch (Throwable t) {
+            if (!loggedReadFailure) {
+                loggedReadFailure = true;
+                LOG.warn("Failed to read LDAP connection pool statistics; reporting them as unavailable.", t);
+            }
+            return LdapPoolSnapshot.unavailable();
+        }
+    }
+
+    /**
+     * Invoking {@code showStats} forces LdapPoolManager's initializer, the same one that runs under
+     * normal LDAP use; it reads the {@code com.sun.jndi.ldap.connect.pool.*} system properties.
+     */
+    private String dumpStats() throws ReflectiveOperationException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream(1024);
+        try (PrintStream out = new PrintStream(buffer, true, StandardCharsets.UTF_8)) {
+            showStats.invoke(null, out);
+        }
+        return buffer.toString(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Turns the dump into a snapshot. The size lines appear twice, once for the manager and once
+     * inside every pool section; only the leading ones are the configured values, so parsing stops
+     * looking for them as soon as the first section starts.
+     */
+    static LdapPoolSnapshot parse(String stats) {
+        DumpReader reader = new DumpReader();
+        for (String line : stats.split("\\R")) {
+            reader.accept(line.trim());
+        }
+        return reader.snapshot();
+    }
+
+    /**
+     * Consumes the dump line by line. Lines before the first section carry the manager's configured
+     * sizes; from the first section header on, every line belongs to the section currently open.
+     */
+    private static final class DumpReader {
+
+        private final Map<String, AuthPoolStats> byAuth = new LinkedHashMap<>();
+
+        private long idleTimeout;
+        private int maxSize;
+        private int prefSize;
+        private int initSize;
+
+        private String auth;
+        private PoolSection section;
+
+        DumpReader() {
+            byAuth.put(AUTH_NONE, AuthPoolStats.empty());
+            byAuth.put(AUTH_SIMPLE, AuthPoolStats.empty());
+            byAuth.put(AUTH_DIGEST, AuthPoolStats.empty());
+        }
+
+        void accept(String line) {
+            String next = sectionOf(line);
+            if (next != null) {
+                closeSection();
+                auth = next;
+                section = new PoolSection();
+            } else if (section == null) {
+                readConfiguration(line);
+            } else {
+                section.accept(line);
+            }
+        }
+
+        private void readConfiguration(String line) {
+            idleTimeout = labelled(line, "idle timeout:", idleTimeout);
+            maxSize = (int) labelled(line, "maximum pool size:", maxSize);
+            prefSize = (int) labelled(line, "preferred pool size:", prefSize);
+            initSize = (int) labelled(line, "initial pool size:", initSize);
+        }
+
+        private void closeSection() {
+            if (auth != null) {
+                byAuth.put(auth, section.toStats());
+            }
+        }
+
+        LdapPoolSnapshot snapshot() {
+            closeSection();
+            if (auth == null) {
+                // Not a single "<mechanism> pools:" section: the format is not what we expect, so the
+                // zeros would be made up rather than measured.
+                return LdapPoolSnapshot.unavailable();
+            }
+            return new LdapPoolSnapshot(true, idleTimeout, maxSize, prefSize, initSize, byAuth);
+        }
+    }
+
+    /** The running totals of the one pool section currently being read. */
+    private static final class PoolSection {
+
+        private int identityPools;
+        private int total;
+        private int idle;
+        private int busy;
+        private int expired;
+
+        void accept(String line) {
+            if (line.startsWith("current pool size:")) {
+                identityPools = (int) labelled(line, "current pool size:", identityPools);
+            } else if (line.contains("size=")) {
+                total += extract(line, "size=");
+                busy += extract(line, "busy=");
+                idle += extract(line, "idle=");
+                expired += extract(line, "expired=");
+            }
+        }
+
+        AuthPoolStats toStats() {
+            return new AuthPoolStats(identityPools, total, idle, busy, expired);
+        }
+    }
+
+    /**
+     * Maps a section header such as {@code "simple auth pools:"} to an authentication label, or
+     * returns {@code null} when the line does not start a section.
+     */
+    private static String sectionOf(String line) {
+        if (!line.endsWith("pools:")) {
+            return null;
+        }
+        String lower = line.toLowerCase(java.util.Locale.ROOT);
+        if (lower.startsWith("anonymous")) {
+            return AUTH_NONE;
+        }
+        if (lower.startsWith("simple")) {
+            return AUTH_SIMPLE;
+        }
+        if (lower.contains("digest")) {
+            return AUTH_DIGEST;
+        }
+        return null;
+    }
+
+    /** Reads the number behind {@code label}, or keeps {@code fallback} when the line does not match. */
+    private static long labelled(String line, String label, long fallback) {
+        if (!line.startsWith(label)) {
+            return fallback;
+        }
+        try {
+            return Long.parseLong(line.substring(label.length()).trim());
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    /**
+     * Extracts the integer value that follows {@code key} in a per-identity line such as
+     * {@code "host:389:::null:cn=admin:size=10; use=45; busy=2; idle=7; expired=1"}. Returns 0 when
+     * the key is absent or the value cannot be parsed.
+     */
+    static int extract(String stats, String key) {
+        int start = stats.indexOf(key);
+        if (start < 0) {
+            return 0;
+        }
+        start += key.length();
+        int end = start;
+        while (end < stats.length() && isNumberChar(stats.charAt(end))) {
+            end++;
+        }
+        try {
+            return Integer.parseInt(stats.substring(start, end));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    /** ASCII digits and a leading minus; the dump never uses grouping separators or decimals. */
+    private static boolean isNumberChar(char c) {
+        return c == '-' || (c >= '0' && c <= '9');
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapPoolMetrics.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapPoolMetrics.java
@@ -1,0 +1,120 @@
+package de.sventorben.keycloak.kommons.ldap;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import java.util.function.ToDoubleFunction;
+
+/**
+ * Registers {@code keycloak_ldap_pool_*} gauges backed by {@link LdapConnectionPoolIntrospector}.
+ *
+ * <p>Exposed meters:
+ * <ul>
+ *   <li>{@code keycloak_ldap_pool_accessible} — 1 if pool statistics can be read from the JDK, else 0</li>
+ *   <li>{@code keycloak_ldap_pool_max_size} / {@code _preferred_size} / {@code _init_size} — configured pool sizing</li>
+ *   <li>{@code keycloak_ldap_pool_timeout_milliseconds} — idle timeout (0 = no timeout)</li>
+ *   <li>{@code keycloak_ldap_pool_identity_pools{authentication}} — number of connection-identity groups</li>
+ *   <li>{@code keycloak_ldap_pool_connections{authentication,state}} — connection counts,
+ *       {@code state} in {@code total|idle|busy|expired}</li>
+ * </ul>
+ *
+ * <p>Each scrape reads a single {@link LdapPoolSnapshot}, memoized for a short interval so the many
+ * gauges do not each trigger a separate reflective pass over the pool.
+ *
+ * <p>Every gauge is registered with a strong reference: Micrometer otherwise keeps only a
+ * {@link java.lang.ref.WeakReference} to the supplier, and once it is collected the gauge reports
+ * {@code NaN} forever. Holding on to this instance elsewhere does not help, the suppliers are
+ * separate objects.
+ */
+final class LdapPoolMetrics implements MeterBinder {
+
+    private static final String PREFIX = "keycloak.ldap.pool";
+    private static final String[] AUTH_LABELS = {"none", "simple", "digest-md5"};
+    private static final String[] CONNECTION_STATES = {"total", "idle", "busy", "expired"};
+    private static final long CACHE_TTL_MILLIS = 2_000L;
+
+    private final LdapConnectionPoolIntrospector introspector;
+
+    private volatile LdapPoolSnapshot cached;
+    private volatile long cachedAtMillis;
+
+    LdapPoolMetrics(LdapConnectionPoolIntrospector introspector) {
+        this.introspector = introspector;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        Gauge.builder(PREFIX + ".accessible", () -> snapshot().accessible() ? 1 : 0)
+            .description("1 if LDAP connection pool statistics can be read from the JDK, 0 otherwise")
+            .strongReference(true)
+            .register(registry);
+
+        configGauge(registry, PREFIX + ".max.size",
+            "Configured maximum number of connections per identity pool (0 = unlimited)",
+            LdapPoolSnapshot::maxSize);
+        configGauge(registry, PREFIX + ".preferred.size",
+            "Configured preferred number of connections per identity pool",
+            LdapPoolSnapshot::prefSize);
+        configGauge(registry, PREFIX + ".init.size",
+            "Configured initial number of connections per identity pool",
+            LdapPoolSnapshot::initSize);
+        configGauge(registry, PREFIX + ".timeout.milliseconds",
+            "Idle timeout after which a pooled connection is closed (0 = no timeout)",
+            LdapPoolSnapshot::idleTimeoutMillis);
+
+        for (String auth : AUTH_LABELS) {
+            Gauge.builder(PREFIX + ".identity.pools",
+                    () -> snapshot().forAuth(auth).identityPools())
+                .description("Number of distinct connection-identity pools (host/port/principal combinations)")
+                .tag("authentication", auth)
+                .strongReference(true)
+                .register(registry);
+
+            for (String state : CONNECTION_STATES) {
+                Gauge.builder(PREFIX + ".connections",
+                        () -> connectionCount(auth, state))
+                    .description("Number of pooled LDAP connections by authentication mechanism and state")
+                    .tag("authentication", auth)
+                    .tag("state", state)
+                    .strongReference(true)
+                    .register(registry);
+            }
+        }
+    }
+
+    private void configGauge(MeterRegistry registry, String name, String description,
+                             ToDoubleFunction<LdapPoolSnapshot> value) {
+        Gauge.builder(name, () -> value.applyAsDouble(snapshot()))
+            .description(description)
+            .strongReference(true)
+            .register(registry);
+    }
+
+    private double connectionCount(String auth, String state) {
+        AuthPoolStats stats = snapshot().forAuth(auth);
+        return switch (state) {
+            case "total" -> stats.total();
+            case "idle" -> stats.idle();
+            case "busy" -> stats.busy();
+            case "expired" -> stats.expired();
+            default -> 0;
+        };
+    }
+
+    private LdapPoolSnapshot snapshot() {
+        long now = System.currentTimeMillis();
+        LdapPoolSnapshot current = cached;
+        if (current != null && (now - cachedAtMillis) < CACHE_TTL_MILLIS) {
+            return current;
+        }
+        synchronized (this) {
+            now = System.currentTimeMillis();
+            if (cached == null || (now - cachedAtMillis) >= CACHE_TTL_MILLIS) {
+                cached = introspector.snapshot();
+                cachedAtMillis = now;
+            }
+            return cached;
+        }
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapPoolMetrics.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapPoolMetrics.java
@@ -30,8 +30,6 @@ import java.util.function.ToDoubleFunction;
 final class LdapPoolMetrics implements MeterBinder {
 
     private static final String PREFIX = "keycloak.ldap.pool";
-    private static final String[] AUTH_LABELS = {"none", "simple", "digest-md5"};
-    private static final String[] CONNECTION_STATES = {"total", "idle", "busy", "expired"};
     private static final long CACHE_TTL_MILLIS = 2_000L;
 
     private final LdapConnectionPoolIntrospector introspector;
@@ -63,20 +61,20 @@ final class LdapPoolMetrics implements MeterBinder {
             "Idle timeout after which a pooled connection is closed (0 = no timeout)",
             LdapPoolSnapshot::idleTimeoutMillis);
 
-        for (String auth : AUTH_LABELS) {
+        for (AuthMechanism auth : AuthMechanism.values()) {
             Gauge.builder(PREFIX + ".identity.pools",
                     () -> snapshot().forAuth(auth).identityPools())
                 .description("Number of distinct connection-identity pools (host/port/principal combinations)")
-                .tag("authentication", auth)
+                .tag("authentication", auth.label())
                 .strongReference(true)
                 .register(registry);
 
-            for (String state : CONNECTION_STATES) {
+            for (ConnectionState state : ConnectionState.values()) {
                 Gauge.builder(PREFIX + ".connections",
-                        () -> connectionCount(auth, state))
+                        () -> state.countIn(snapshot().forAuth(auth)))
                     .description("Number of pooled LDAP connections by authentication mechanism and state")
-                    .tag("authentication", auth)
-                    .tag("state", state)
+                    .tag("authentication", auth.label())
+                    .tag("state", state.label())
                     .strongReference(true)
                     .register(registry);
             }
@@ -89,17 +87,6 @@ final class LdapPoolMetrics implements MeterBinder {
             .description(description)
             .strongReference(true)
             .register(registry);
-    }
-
-    private double connectionCount(String auth, String state) {
-        AuthPoolStats stats = snapshot().forAuth(auth);
-        return switch (state) {
-            case "total" -> stats.total();
-            case "idle" -> stats.idle();
-            case "busy" -> stats.busy();
-            case "expired" -> stats.expired();
-            default -> 0;
-        };
     }
 
     private LdapPoolSnapshot snapshot() {

--- a/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapPoolMetricsEventListenerProviderFactory.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapPoolMetricsEventListenerProviderFactory.java
@@ -1,0 +1,104 @@
+package de.sventorben.keycloak.kommons.ldap;
+
+import io.micrometer.core.instrument.Metrics;
+import org.jboss.logging.Logger;
+import org.keycloak.Config;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Registers {@link LdapPoolMetrics} with the global Micrometer registry at server startup, so the
+ * {@code keycloak_ldap_pool_*} gauges appear on Keycloak's {@code /metrics} endpoint (management
+ * port, enabled via {@code --metrics-enabled=true}).
+ *
+ * <p>Opt-in, because the underlying introspection reads JDK internals and needs extra
+ * {@code --add-opens} flags to work:
+ *
+ * <pre>
+ * --spi-events-listener-kommons-ldap-pool-metrics-enabled=true
+ * </pre>
+ *
+ * <p>This factory is used purely as a startup hook: Keycloak instantiates and initialises every
+ * enabled provider factory at boot, regardless of realm configuration. The
+ * {@link EventListenerProvider} it creates is a no-op and does <em>not</em> need to be enabled as an
+ * event listener in any realm.
+ */
+public final class LdapPoolMetricsEventListenerProviderFactory
+    implements EventListenerProviderFactory, EnvironmentDependentProviderFactory {
+
+    static final String PROVIDER_ID = "kommons-ldap-pool-metrics";
+
+    private static final Logger LOG = Logger.getLogger(LdapPoolMetricsEventListenerProviderFactory.class);
+    private static final AtomicBoolean REGISTERED = new AtomicBoolean(false);
+
+    // Strong reference so the gauge suppliers (and their introspector) are never garbage collected.
+    private LdapPoolMetrics metrics;
+
+    @Override
+    public EventListenerProvider create(KeycloakSession session) {
+        return NoopEventListenerProvider.INSTANCE;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        // Guarded because a session factory rebuild re-inits the factory, and re-binding would
+        // register a second set of gauges on the (process-global) Micrometer registry.
+        if (REGISTERED.compareAndSet(false, true)) {
+            LdapConnectionPoolIntrospector introspector = new LdapConnectionPoolIntrospector();
+            metrics = new LdapPoolMetrics(introspector);
+            metrics.bindTo(Metrics.globalRegistry);
+            LOG.infof("Registered LDAP connection pool metrics (keycloak_ldap_pool_*); "
+                + "JDK introspection available: %s", introspector.isAvailable());
+        }
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return config.getBoolean("enabled", false);
+    }
+
+    @Override
+    public boolean isGlobal() {
+        // Deliberately false. "Global" here controls event fan-out, not lifecycle: returning true
+        // would dispatch every realm's events to the no-op provider below for no benefit. The pool
+        // being process-global is unrelated -- registration happens in init() either way.
+        return false;
+    }
+
+    private static final class NoopEventListenerProvider implements EventListenerProvider {
+
+        static final NoopEventListenerProvider INSTANCE = new NoopEventListenerProvider();
+
+        @Override
+        public void onEvent(Event event) {
+        }
+
+        @Override
+        public void onEvent(AdminEvent adminEvent, boolean includeRepresentation) {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapPoolSnapshot.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapPoolSnapshot.java
@@ -1,0 +1,38 @@
+package de.sventorben.keycloak.kommons.ldap;
+
+import java.util.Map;
+
+/**
+ * Immutable point-in-time view of the JVM-global JNDI/LDAP connection pool
+ * ({@code com.sun.jndi.ldap.LdapPoolManager}).
+ *
+ * @param accessible        {@code true} if the values were read from the JDK; {@code false} if the
+ *                          JDK internals could not be accessed (in which case all numeric fields are 0)
+ * @param idleTimeoutMillis idle timeout in milliseconds before a pooled connection is closed (0 = no timeout)
+ * @param maxSize           configured maximum connections per identity pool (0 = unlimited)
+ * @param prefSize          configured preferred connections per identity pool
+ * @param initSize          configured initial connections per identity pool
+ * @param byAuth            per-authentication-mechanism connection statistics, keyed by
+ *                          {@code none}, {@code simple}, {@code digest-md5}
+ */
+record LdapPoolSnapshot(
+    boolean accessible,
+    long idleTimeoutMillis,
+    int maxSize,
+    int prefSize,
+    int initSize,
+    Map<String, AuthPoolStats> byAuth) {
+
+    private static final Map<String, AuthPoolStats> EMPTY_BY_AUTH = Map.of(
+        "none", AuthPoolStats.empty(),
+        "simple", AuthPoolStats.empty(),
+        "digest-md5", AuthPoolStats.empty());
+
+    static LdapPoolSnapshot unavailable() {
+        return new LdapPoolSnapshot(false, 0L, 0, 0, 0, EMPTY_BY_AUTH);
+    }
+
+    AuthPoolStats forAuth(String authentication) {
+        return byAuth.getOrDefault(authentication, AuthPoolStats.empty());
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapPoolSnapshot.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/ldap/LdapPoolSnapshot.java
@@ -1,5 +1,6 @@
 package de.sventorben.keycloak.kommons.ldap;
 
+import java.util.EnumMap;
 import java.util.Map;
 
 /**
@@ -12,8 +13,7 @@ import java.util.Map;
  * @param maxSize           configured maximum connections per identity pool (0 = unlimited)
  * @param prefSize          configured preferred connections per identity pool
  * @param initSize          configured initial connections per identity pool
- * @param byAuth            per-authentication-mechanism connection statistics, keyed by
- *                          {@code none}, {@code simple}, {@code digest-md5}
+ * @param byAuth            per-authentication-mechanism connection statistics
  */
 record LdapPoolSnapshot(
     boolean accessible,
@@ -21,18 +21,23 @@ record LdapPoolSnapshot(
     int maxSize,
     int prefSize,
     int initSize,
-    Map<String, AuthPoolStats> byAuth) {
+    Map<AuthMechanism, AuthPoolStats> byAuth) {
 
-    private static final Map<String, AuthPoolStats> EMPTY_BY_AUTH = Map.of(
-        "none", AuthPoolStats.empty(),
-        "simple", AuthPoolStats.empty(),
-        "digest-md5", AuthPoolStats.empty());
+    private static final Map<AuthMechanism, AuthPoolStats> EMPTY_BY_AUTH = emptyByAuth();
 
     static LdapPoolSnapshot unavailable() {
         return new LdapPoolSnapshot(false, 0L, 0, 0, 0, EMPTY_BY_AUTH);
     }
 
-    AuthPoolStats forAuth(String authentication) {
-        return byAuth.getOrDefault(authentication, AuthPoolStats.empty());
+    AuthPoolStats forAuth(AuthMechanism mechanism) {
+        return byAuth.getOrDefault(mechanism, AuthPoolStats.empty());
+    }
+
+    private static Map<AuthMechanism, AuthPoolStats> emptyByAuth() {
+        Map<AuthMechanism, AuthPoolStats> empty = new EnumMap<>(AuthMechanism.class);
+        for (AuthMechanism mechanism : AuthMechanism.values()) {
+            empty.put(mechanism, AuthPoolStats.empty());
+        }
+        return Map.copyOf(empty);
     }
 }

--- a/src/main/java/de/sventorben/keycloak/kommons/ldap/PoolDumpLine.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/ldap/PoolDumpLine.java
@@ -1,0 +1,106 @@
+package de.sventorben.keycloak.kommons.ldap;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * A single trimmed line of the {@code LdapPoolManager#showStats} dump, together with the small
+ * vocabulary needed to read it. Keeping that vocabulary here means the parser states below deal in
+ * fields and counters rather than in substring arithmetic.
+ *
+ * <p>Two shapes of line carry numbers. A {@link Field} line labels one value:
+ * <pre>
+ * maximum pool size: 20
+ * </pre>
+ * A connection-identity line packs several {@link Counter}s behind a host/principal key:
+ * <pre>
+ * localhost:389:::null:cn=admin,dc=example,dc=org:size=2; use=2; busy=2; idle=0; expired=0
+ * </pre>
+ */
+record PoolDumpLine(String text) {
+
+    /** A labelled numeric field, written as {@code "<label> <number>"} at the start of a line. */
+    enum Field {
+
+        IDLE_TIMEOUT("idle timeout:"),
+        MAX_SIZE("maximum pool size:"),
+        PREFERRED_SIZE("preferred pool size:"),
+        INITIAL_SIZE("initial pool size:"),
+        /** Inside a section: how many connection identities that pool currently holds. */
+        CURRENT_POOL_SIZE("current pool size:");
+
+        private final String label;
+
+        Field(String label) {
+            this.label = label;
+        }
+    }
+
+    /** A per-identity counter, written as {@code "<key><number>"} within a single line. */
+    enum Counter {
+
+        SIZE("size="),
+        BUSY("busy="),
+        IDLE("idle="),
+        EXPIRED("expired=");
+
+        private final String key;
+
+        Counter(String key) {
+            this.key = key;
+        }
+    }
+
+    static PoolDumpLine of(String raw) {
+        return new PoolDumpLine(raw.trim());
+    }
+
+    /** The mechanism whose section this line opens, or empty when it opens no section. */
+    Optional<AuthMechanism> opensSectionFor() {
+        return AuthMechanism.ofSectionHeader(text);
+    }
+
+    /** Whether this is a connection-identity line, i.e. one carrying {@link Counter}s. */
+    boolean holdsIdentityCounters() {
+        return text.contains(Counter.SIZE.key);
+    }
+
+    /**
+     * The value of {@code field}, or empty when this line does not carry it. Empty is also the
+     * answer for a label whose value will not parse, so a garbled dump keeps whatever the parser
+     * had rather than resetting it.
+     */
+    OptionalLong valueOf(Field field) {
+        if (!text.startsWith(field.label)) {
+            return OptionalLong.empty();
+        }
+        try {
+            return OptionalLong.of(Long.parseLong(text.substring(field.label.length()).trim()));
+        } catch (NumberFormatException e) {
+            return OptionalLong.empty();
+        }
+    }
+
+    /** The value of {@code counter}, or 0 when it is absent or unparseable. */
+    int countOf(Counter counter) {
+        int start = text.indexOf(counter.key);
+        if (start < 0) {
+            return 0;
+        }
+        start += counter.key.length();
+        int end = start;
+        while (end < text.length() && isNumberChar(text.charAt(end))) {
+            end++;
+        }
+        try {
+            return Integer.parseInt(text.substring(start, end));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    /** ASCII digits and a leading minus; the dump never uses grouping separators or decimals. */
+    private static boolean isNumberChar(char c) {
+        return c == '-' || (c >= '0' && c <= '9');
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/kommons/ldap/PoolDumpParser.java
+++ b/src/main/java/de/sventorben/keycloak/kommons/ldap/PoolDumpParser.java
@@ -1,0 +1,113 @@
+package de.sventorben.keycloak.kommons.ldap;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Turns the {@code LdapPoolManager#showStats} dump into an {@link LdapPoolSnapshot}.
+ *
+ * <p>The dump is a flat sequence of lines with one piece of structure: a header such as
+ * {@code "simple auth pools:"} opens a section, and everything after it belongs to that section
+ * until the next header. The size fields appear twice, once for the manager and once inside every
+ * section, so only the ones seen before the first header are the configured values.
+ *
+ * <p>When not a single section is recognised the dump is not what we expect, and the result is
+ * {@link LdapPoolSnapshot#unavailable()} rather than a snapshot full of zeros: the zeros would be
+ * invented rather than measured, and {@code accessible} is precisely the signal operators alert on.
+ */
+final class PoolDumpParser {
+
+    private PoolDumpParser() {
+    }
+
+    static LdapPoolSnapshot parse(String dump) {
+        DumpReader reader = new DumpReader();
+        for (String line : dump.split("\\R")) {
+            reader.accept(PoolDumpLine.of(line));
+        }
+        return reader.snapshot();
+    }
+
+    /**
+     * Consumes the dump line by line. Lines before the first section carry the manager's configured
+     * sizes; from the first section header on, every line belongs to the section currently open.
+     */
+    private static final class DumpReader {
+
+        private final Map<AuthMechanism, AuthPoolStats> byAuth = new EnumMap<>(AuthMechanism.class);
+
+        private long idleTimeout;
+        private int maxSize;
+        private int prefSize;
+        private int initSize;
+
+        private AuthMechanism mechanism;
+        private PoolSection section;
+
+        DumpReader() {
+            for (AuthMechanism known : AuthMechanism.values()) {
+                byAuth.put(known, AuthPoolStats.empty());
+            }
+        }
+
+        void accept(PoolDumpLine line) {
+            line.opensSectionFor().ifPresentOrElse(next -> {
+                closeSection();
+                mechanism = next;
+                section = new PoolSection();
+            }, () -> {
+                if (section == null) {
+                    readConfiguration(line);
+                } else {
+                    section.accept(line);
+                }
+            });
+        }
+
+        private void readConfiguration(PoolDumpLine line) {
+            line.valueOf(PoolDumpLine.Field.IDLE_TIMEOUT).ifPresent(value -> idleTimeout = value);
+            line.valueOf(PoolDumpLine.Field.MAX_SIZE).ifPresent(value -> maxSize = (int) value);
+            line.valueOf(PoolDumpLine.Field.PREFERRED_SIZE).ifPresent(value -> prefSize = (int) value);
+            line.valueOf(PoolDumpLine.Field.INITIAL_SIZE).ifPresent(value -> initSize = (int) value);
+        }
+
+        private void closeSection() {
+            if (mechanism != null) {
+                byAuth.put(mechanism, section.toStats());
+            }
+        }
+
+        LdapPoolSnapshot snapshot() {
+            closeSection();
+            if (mechanism == null) {
+                return LdapPoolSnapshot.unavailable();
+            }
+            return new LdapPoolSnapshot(true, idleTimeout, maxSize, prefSize, initSize, byAuth);
+        }
+    }
+
+    /** The running totals of the one pool section currently being read. */
+    private static final class PoolSection {
+
+        private int identityPools;
+        private int total;
+        private int idle;
+        private int busy;
+        private int expired;
+
+        void accept(PoolDumpLine line) {
+            line.valueOf(PoolDumpLine.Field.CURRENT_POOL_SIZE)
+                .ifPresent(value -> identityPools = (int) value);
+            if (line.holdsIdentityCounters()) {
+                total += line.countOf(PoolDumpLine.Counter.SIZE);
+                busy += line.countOf(PoolDumpLine.Counter.BUSY);
+                idle += line.countOf(PoolDumpLine.Counter.IDLE);
+                expired += line.countOf(PoolDumpLine.Counter.EXPIRED);
+            }
+        }
+
+        AuthPoolStats toStats() {
+            return new AuthPoolStats(identityPools, total, idle, busy, expired);
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
@@ -1,1 +1,2 @@
 de.sventorben.keycloak.kommons.auth.UnusualLoginTimeEventListenerProvider
+de.sventorben.keycloak.kommons.ldap.LdapPoolMetricsEventListenerProviderFactory

--- a/src/test/java/de/sventorben/keycloak/kommons/ldap/LdapConnectionPoolIntrospectorTest.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/ldap/LdapConnectionPoolIntrospectorTest.java
@@ -1,0 +1,206 @@
+package de.sventorben.keycloak.kommons.ldap;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for parsing {@code com.sun.jndi.ldap.LdapPoolManager#showStats(PrintStream)}.
+ *
+ * <p>The fixtures below are verbatim output of a real JDK 21 run against an OpenLDAP server, so the
+ * parser is pinned to the actual format rather than to an assumption about it. The reflective call
+ * itself is exercised end-to-end by {@link LdapPoolMetricsIT} inside a running Keycloak.
+ */
+class LdapConnectionPoolIntrospectorTest {
+
+    /** Two pooled connections against one directory, both in use, digest pool not enabled. */
+    private static final String POPULATED = """
+        ***** start *****
+        idle timeout: 300000
+        maximum pool size: 20
+        preferred pool size: 5
+        initial pool size: 1
+        protocol types: plain\s
+        authentication types: none simple\s
+        anonymous pools:
+        ===== Pool start ======================
+        maximum pool size: 20
+        preferred pool size: 5
+        initial pool size: 1
+        current pool size: 0
+        ====== Pool end =====================
+        simple auth pools:
+        ===== Pool start ======================
+        maximum pool size: 20
+        preferred pool size: 5
+        initial pool size: 1
+        current pool size: 1
+           localhost:1389:::null:cn=admin,dc=example,dc=org:size=2; use=2; busy=2; idle=0; expired=0
+        ====== Pool end =====================
+        ***** end *****
+        """;
+
+    /** Nothing has connected yet: pools exist but hold no connections. */
+    private static final String EMPTY = """
+        ***** start *****
+        idle timeout: 0
+        maximum pool size: 0
+        preferred pool size: 0
+        initial pool size: 1
+        protocol types: plain\s
+        authentication types: none simple\s
+        anonymous pools:
+        ===== Pool start ======================
+        current pool size: 0
+        ====== Pool end =====================
+        simple auth pools:
+        ===== Pool start ======================
+        current pool size: 0
+        ====== Pool end =====================
+        ***** end *****
+        """;
+
+    // --- configuration ------------------------------------------------------------------------------------------
+
+    @Test
+    void readsTheConfiguredSizesFromTheHeader() {
+        LdapPoolSnapshot snapshot = LdapConnectionPoolIntrospector.parse(POPULATED);
+
+        assertThat(snapshot.accessible()).isTrue();
+        assertThat(snapshot)
+            .extracting(LdapPoolSnapshot::idleTimeoutMillis, LdapPoolSnapshot::maxSize,
+                LdapPoolSnapshot::prefSize, LdapPoolSnapshot::initSize)
+            .containsExactly(300000L, 20, 5, 1);
+    }
+
+    @Test
+    void theSizesRepeatedInsideEachPoolSectionDoNotOverwriteTheHeader() {
+        // Every section repeats "maximum pool size:" etc. Only the leading ones are the configuration.
+        String misleading = POPULATED.replace("""
+            maximum pool size: 20
+            preferred pool size: 5
+            initial pool size: 1
+            current pool size: 1""", """
+            maximum pool size: 999
+            preferred pool size: 888
+            initial pool size: 777
+            current pool size: 1""");
+
+        LdapPoolSnapshot snapshot = LdapConnectionPoolIntrospector.parse(misleading);
+
+        assertThat(snapshot.maxSize()).isEqualTo(20);
+        assertThat(snapshot.prefSize()).isEqualTo(5);
+        assertThat(snapshot.initSize()).isEqualTo(1);
+    }
+
+    // --- per authentication mechanism ---------------------------------------------------------------------------
+
+    @Test
+    void countsTheConnectionsOfTheSimplePool() {
+        AuthPoolStats simple = LdapConnectionPoolIntrospector.parse(POPULATED).forAuth("simple");
+
+        // identityPools, total, idle, busy, expired
+        assertThat(simple).isEqualTo(new AuthPoolStats(1, 2, 0, 2, 0));
+    }
+
+    @Test
+    void anEmptySectionYieldsZeros() {
+        AuthPoolStats anonymous = LdapConnectionPoolIntrospector.parse(POPULATED).forAuth("none");
+
+        assertThat(anonymous.identityPools()).isZero();
+        assertThat(anonymous.total()).isZero();
+    }
+
+    @Test
+    void aMechanismWithoutASectionIsReportedAsEmpty() {
+        // The digest pool is not created unless it is enabled, so it never shows up in the dump.
+        assertThat(LdapConnectionPoolIntrospector.parse(POPULATED).forAuth("digest-md5"))
+            .isEqualTo(AuthPoolStats.empty());
+    }
+
+    @Test
+    void severalIdentityPoolsAreSummedUp() {
+        String twoDirectories = POPULATED.replace(
+            "   localhost:1389:::null:cn=admin,dc=example,dc=org:size=2; use=2; busy=2; idle=0; expired=0",
+            """
+               localhost:1389:::null:cn=admin,dc=example,dc=org:size=2; use=2; busy=2; idle=0; expired=0
+               other:389:::null:cn=svc,dc=example,dc=org:size=3; use=9; busy=1; idle=2; expired=1""")
+            .replace("current pool size: 1", "current pool size: 2");
+
+        AuthPoolStats simple = LdapConnectionPoolIntrospector.parse(twoDirectories).forAuth("simple");
+
+        // identityPools, total, idle, busy, expired
+        assertThat(simple).isEqualTo(new AuthPoolStats(2, 5, 2, 3, 1));
+    }
+
+    @Test
+    void anIdlePoolIsReportedAsIdleRatherThanBusy() {
+        String idled = POPULATED.replace(
+            "size=2; use=2; busy=2; idle=0; expired=0",
+            "size=2; use=7; busy=0; idle=2; expired=0");
+
+        AuthPoolStats simple = LdapConnectionPoolIntrospector.parse(idled).forAuth("simple");
+
+        assertThat(simple.busy()).isZero();
+        assertThat(simple.idle()).isEqualTo(2);
+        assertThat(simple.total()).isEqualTo(2);
+    }
+
+    @Test
+    void aPoolNobodyHasUsedYetIsAllZeros() {
+        LdapPoolSnapshot snapshot = LdapConnectionPoolIntrospector.parse(EMPTY);
+
+        assertThat(snapshot.accessible()).isTrue();
+        assertThat(snapshot.forAuth("none")).isEqualTo(AuthPoolStats.empty());
+        assertThat(snapshot.forAuth("simple")).isEqualTo(AuthPoolStats.empty());
+    }
+
+    // --- robustness ---------------------------------------------------------------------------------------------
+
+    @Test
+    void anUnrecognisableDumpIsReportedAsUnavailable() {
+        // Reporting zeros here would be inventing numbers. accessible=0 is the honest answer, and it
+        // is what operators alert on.
+        LdapPoolSnapshot snapshot = LdapConnectionPoolIntrospector.parse("something else entirely");
+
+        assertThat(snapshot.accessible()).isFalse();
+        assertThat(snapshot.maxSize()).isZero();
+        assertThat(snapshot.forAuth("simple")).isEqualTo(AuthPoolStats.empty());
+    }
+
+    @Test
+    void aRenamedSectionHeaderIsNoticedRatherThanSilentlyIgnored() {
+        // If a future JDK renames the section headers, every count would parse to zero. That must
+        // surface as accessible=0 instead of looking like an idle pool.
+        String renamed = POPULATED
+            .replace("anonymous pools:", "anonymous connection groups:")
+            .replace("simple auth pools:", "simple auth connection groups:");
+
+        assertThat(LdapConnectionPoolIntrospector.parse(renamed).accessible()).isFalse();
+    }
+
+    @Test
+    void aNonNumericValueFallsBackInsteadOfThrowing() {
+        String garbled = POPULATED.replace("idle timeout: 300000", "idle timeout: soon");
+
+        assertThat(LdapConnectionPoolIntrospector.parse(garbled).idleTimeoutMillis()).isZero();
+    }
+
+    // --- the per-identity value extractor -----------------------------------------------------------------------
+
+    @Test
+    void extractsEachCountFromAStatsLine() {
+        String line = "host:389:::null:cn=admin:size=10; use=45; busy=2; idle=7; expired=1";
+
+        assertThat(LdapConnectionPoolIntrospector.extract(line, "size=")).isEqualTo(10);
+        assertThat(LdapConnectionPoolIntrospector.extract(line, "busy=")).isEqualTo(2);
+        assertThat(LdapConnectionPoolIntrospector.extract(line, "idle=")).isEqualTo(7);
+        assertThat(LdapConnectionPoolIntrospector.extract(line, "expired=")).isEqualTo(1);
+    }
+
+    @Test
+    void extractReturnsZeroForAMissingOrMalformedKey() {
+        assertThat(LdapConnectionPoolIntrospector.extract("size=10", "missing=")).isZero();
+        assertThat(LdapConnectionPoolIntrospector.extract("size=; idle=3", "size=")).isZero();
+    }
+}

--- a/src/test/java/de/sventorben/keycloak/kommons/ldap/LdapPoolMetricsIT.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/ldap/LdapPoolMetricsIT.java
@@ -1,0 +1,95 @@
+package de.sventorben.keycloak.kommons.ldap;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import de.sventorben.keycloak.kommons.KeycloakDockerContainer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the LDAP connection pool metrics.
+ *
+ * <p>A real Keycloak instance runs in Docker with our provider classes loaded from
+ * {@code target/classes}, metrics enabled ({@code KC_METRICS_ENABLED=true}), the provider itself
+ * switched on (it is opt-in) and the JDK-internal {@code java.naming} package exported for
+ * reflection via {@code JAVA_OPTS_APPEND}. The test scrapes the Prometheus endpoint on the
+ * management port and asserts that the {@code keycloak_ldap_pool_*} series are present and readable.
+ *
+ * <p>No LDAP user federation is configured, so the connection counts are zero; the point under test
+ * is that the metrics are exported and that {@code keycloak_ldap_pool_accessible} reports {@code 1}
+ * when the required {@code --add-exports} flag is present.
+ */
+@Testcontainers
+class LdapPoolMetricsIT {
+
+    private static final String ADD_EXPORTS =
+        "--add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED";
+
+    /** The provider is opt-in, so without this nothing registers and no gauge is exported at all. */
+    private static final String ENABLE_PROVIDER =
+        "--spi-events-listener--kommons-ldap-pool-metrics--enabled=true";
+
+    @Container
+    private static final KeycloakContainer KEYCLOAK = KeycloakDockerContainer.create()
+        .withEnabledMetrics()
+        .withCustomCommand(ENABLE_PROVIDER)
+        .withEnv("JAVA_OPTS_APPEND", ADD_EXPORTS);
+
+    private static HttpClient http;
+    private static String metricsUrl;
+
+    @BeforeAll
+    static void setUp() {
+        http = HttpClient.newHttpClient();
+        metricsUrl = KEYCLOAK.getMgmtServerUrl() + "/metrics";
+    }
+
+    @Test
+    @DisplayName("keycloak_ldap_pool_accessible reports 1 when the JDK internals are opened")
+    void accessibleIsOne() throws Exception {
+        String metrics = scrapeMetrics();
+        assertThat(metrics).containsPattern("keycloak_ldap_pool_accessible(\\{[^}]*})? 1\\.0");
+    }
+
+    @Test
+    @DisplayName("pool configuration gauges are exported")
+    void configurationGaugesExported() throws Exception {
+        String metrics = scrapeMetrics();
+        assertThat(metrics).contains("keycloak_ldap_pool_max_size");
+        assertThat(metrics).contains("keycloak_ldap_pool_preferred_size");
+        assertThat(metrics).contains("keycloak_ldap_pool_init_size");
+        assertThat(metrics).contains("keycloak_ldap_pool_timeout_milliseconds");
+    }
+
+    @Test
+    @DisplayName("connection gauges are split by authentication and state")
+    void connectionGaugesSplitByAuthenticationAndState() throws Exception {
+        String metrics = scrapeMetrics();
+        // no LDAP configured, so every count is 0.0
+        assertThat(metrics).containsPattern(
+            "keycloak_ldap_pool_connections\\{[^}]*authentication=\"simple\"[^}]*state=\"idle\"[^}]*} 0\\.0");
+        assertThat(metrics).containsPattern(
+            "keycloak_ldap_pool_connections\\{[^}]*authentication=\"none\"[^}]*state=\"busy\"[^}]*} 0\\.0");
+        assertThat(metrics).contains("keycloak_ldap_pool_identity_pools");
+        assertThat(metrics).contains("authentication=\"digest-md5\"");
+    }
+
+    private String scrapeMetrics() throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(metricsUrl))
+            .GET()
+            .build();
+        HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(200);
+        return response.body();
+    }
+}

--- a/src/test/java/de/sventorben/keycloak/kommons/ldap/PoolDumpLineTest.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/ldap/PoolDumpLineTest.java
@@ -1,0 +1,59 @@
+package de.sventorben.keycloak.kommons.ldap;
+
+import org.junit.jupiter.api.Test;
+
+import static de.sventorben.keycloak.kommons.ldap.PoolDumpLine.Counter.BUSY;
+import static de.sventorben.keycloak.kommons.ldap.PoolDumpLine.Counter.EXPIRED;
+import static de.sventorben.keycloak.kommons.ldap.PoolDumpLine.Counter.IDLE;
+import static de.sventorben.keycloak.kommons.ldap.PoolDumpLine.Counter.SIZE;
+import static de.sventorben.keycloak.kommons.ldap.PoolDumpLine.Field.IDLE_TIMEOUT;
+import static de.sventorben.keycloak.kommons.ldap.PoolDumpLine.Field.MAX_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for reading the two numeric shapes of line in the pool dump. */
+class PoolDumpLineTest {
+
+    @Test
+    void extractsEachCounterFromAConnectionIdentityLine() {
+        PoolDumpLine line = PoolDumpLine.of(
+            "host:389:::null:cn=admin:size=10; use=45; busy=2; idle=7; expired=1");
+
+        assertThat(line.holdsIdentityCounters()).isTrue();
+        assertThat(line.countOf(SIZE)).isEqualTo(10);
+        assertThat(line.countOf(BUSY)).isEqualTo(2);
+        assertThat(line.countOf(IDLE)).isEqualTo(7);
+        assertThat(line.countOf(EXPIRED)).isEqualTo(1);
+    }
+
+    @Test
+    void aCounterThatIsAbsentOrMalformedCountsAsZero() {
+        assertThat(PoolDumpLine.of("size=10").countOf(BUSY)).isZero();
+        assertThat(PoolDumpLine.of("size=; idle=3").countOf(SIZE)).isZero();
+    }
+
+    @Test
+    void readsALabelledFieldOnlyFromTheLineThatCarriesIt() {
+        assertThat(PoolDumpLine.of("idle timeout: 300000").valueOf(IDLE_TIMEOUT)).hasValue(300000L);
+        assertThat(PoolDumpLine.of("idle timeout: 300000").valueOf(MAX_SIZE)).isEmpty();
+    }
+
+    @Test
+    void aLabelWithANonNumericValueIsReportedAsAbsent() {
+        // The caller keeps whatever it had rather than resetting it to zero.
+        assertThat(PoolDumpLine.of("idle timeout: soon").valueOf(IDLE_TIMEOUT)).isEmpty();
+    }
+
+    @Test
+    void recognisesTheSectionHeaderOfEachMechanism() {
+        assertThat(PoolDumpLine.of("anonymous pools:").opensSectionFor()).contains(AuthMechanism.NONE);
+        assertThat(PoolDumpLine.of("simple auth pools:").opensSectionFor()).contains(AuthMechanism.SIMPLE);
+        assertThat(PoolDumpLine.of("DIGEST-MD5 auth pools:").opensSectionFor())
+            .contains(AuthMechanism.DIGEST_MD5);
+    }
+
+    @Test
+    void aLineThatDoesNotEndInPoolsOpensNoSection() {
+        assertThat(PoolDumpLine.of("anonymous connection groups:").opensSectionFor()).isEmpty();
+        assertThat(PoolDumpLine.of("current pool size: 1").opensSectionFor()).isEmpty();
+    }
+}

--- a/src/test/java/de/sventorben/keycloak/kommons/ldap/PoolDumpParserTest.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/ldap/PoolDumpParserTest.java
@@ -2,6 +2,9 @@ package de.sventorben.keycloak.kommons.ldap;
 
 import org.junit.jupiter.api.Test;
 
+import static de.sventorben.keycloak.kommons.ldap.AuthMechanism.DIGEST_MD5;
+import static de.sventorben.keycloak.kommons.ldap.AuthMechanism.NONE;
+import static de.sventorben.keycloak.kommons.ldap.AuthMechanism.SIMPLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -9,9 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>The fixtures below are verbatim output of a real JDK 21 run against an OpenLDAP server, so the
  * parser is pinned to the actual format rather than to an assumption about it. The reflective call
- * itself is exercised end-to-end by {@link LdapPoolMetricsIT} inside a running Keycloak.
+ * that produces the dump is exercised end-to-end by {@link LdapPoolMetricsIT} inside a running
+ * Keycloak.
  */
-class LdapConnectionPoolIntrospectorTest {
+class PoolDumpParserTest {
 
     /** Two pooled connections against one directory, both in use, digest pool not enabled. */
     private static final String POPULATED = """
@@ -64,7 +68,7 @@ class LdapConnectionPoolIntrospectorTest {
 
     @Test
     void readsTheConfiguredSizesFromTheHeader() {
-        LdapPoolSnapshot snapshot = LdapConnectionPoolIntrospector.parse(POPULATED);
+        LdapPoolSnapshot snapshot = PoolDumpParser.parse(POPULATED);
 
         assertThat(snapshot.accessible()).isTrue();
         assertThat(snapshot)
@@ -86,7 +90,7 @@ class LdapConnectionPoolIntrospectorTest {
             initial pool size: 777
             current pool size: 1""");
 
-        LdapPoolSnapshot snapshot = LdapConnectionPoolIntrospector.parse(misleading);
+        LdapPoolSnapshot snapshot = PoolDumpParser.parse(misleading);
 
         assertThat(snapshot.maxSize()).isEqualTo(20);
         assertThat(snapshot.prefSize()).isEqualTo(5);
@@ -97,7 +101,7 @@ class LdapConnectionPoolIntrospectorTest {
 
     @Test
     void countsTheConnectionsOfTheSimplePool() {
-        AuthPoolStats simple = LdapConnectionPoolIntrospector.parse(POPULATED).forAuth("simple");
+        AuthPoolStats simple = PoolDumpParser.parse(POPULATED).forAuth(SIMPLE);
 
         // identityPools, total, idle, busy, expired
         assertThat(simple).isEqualTo(new AuthPoolStats(1, 2, 0, 2, 0));
@@ -105,7 +109,7 @@ class LdapConnectionPoolIntrospectorTest {
 
     @Test
     void anEmptySectionYieldsZeros() {
-        AuthPoolStats anonymous = LdapConnectionPoolIntrospector.parse(POPULATED).forAuth("none");
+        AuthPoolStats anonymous = PoolDumpParser.parse(POPULATED).forAuth(NONE);
 
         assertThat(anonymous.identityPools()).isZero();
         assertThat(anonymous.total()).isZero();
@@ -114,7 +118,7 @@ class LdapConnectionPoolIntrospectorTest {
     @Test
     void aMechanismWithoutASectionIsReportedAsEmpty() {
         // The digest pool is not created unless it is enabled, so it never shows up in the dump.
-        assertThat(LdapConnectionPoolIntrospector.parse(POPULATED).forAuth("digest-md5"))
+        assertThat(PoolDumpParser.parse(POPULATED).forAuth(DIGEST_MD5))
             .isEqualTo(AuthPoolStats.empty());
     }
 
@@ -127,7 +131,7 @@ class LdapConnectionPoolIntrospectorTest {
                other:389:::null:cn=svc,dc=example,dc=org:size=3; use=9; busy=1; idle=2; expired=1""")
             .replace("current pool size: 1", "current pool size: 2");
 
-        AuthPoolStats simple = LdapConnectionPoolIntrospector.parse(twoDirectories).forAuth("simple");
+        AuthPoolStats simple = PoolDumpParser.parse(twoDirectories).forAuth(SIMPLE);
 
         // identityPools, total, idle, busy, expired
         assertThat(simple).isEqualTo(new AuthPoolStats(2, 5, 2, 3, 1));
@@ -139,7 +143,7 @@ class LdapConnectionPoolIntrospectorTest {
             "size=2; use=2; busy=2; idle=0; expired=0",
             "size=2; use=7; busy=0; idle=2; expired=0");
 
-        AuthPoolStats simple = LdapConnectionPoolIntrospector.parse(idled).forAuth("simple");
+        AuthPoolStats simple = PoolDumpParser.parse(idled).forAuth(SIMPLE);
 
         assertThat(simple.busy()).isZero();
         assertThat(simple.idle()).isEqualTo(2);
@@ -148,11 +152,11 @@ class LdapConnectionPoolIntrospectorTest {
 
     @Test
     void aPoolNobodyHasUsedYetIsAllZeros() {
-        LdapPoolSnapshot snapshot = LdapConnectionPoolIntrospector.parse(EMPTY);
+        LdapPoolSnapshot snapshot = PoolDumpParser.parse(EMPTY);
 
         assertThat(snapshot.accessible()).isTrue();
-        assertThat(snapshot.forAuth("none")).isEqualTo(AuthPoolStats.empty());
-        assertThat(snapshot.forAuth("simple")).isEqualTo(AuthPoolStats.empty());
+        assertThat(snapshot.forAuth(NONE)).isEqualTo(AuthPoolStats.empty());
+        assertThat(snapshot.forAuth(SIMPLE)).isEqualTo(AuthPoolStats.empty());
     }
 
     // --- robustness ---------------------------------------------------------------------------------------------
@@ -161,11 +165,11 @@ class LdapConnectionPoolIntrospectorTest {
     void anUnrecognisableDumpIsReportedAsUnavailable() {
         // Reporting zeros here would be inventing numbers. accessible=0 is the honest answer, and it
         // is what operators alert on.
-        LdapPoolSnapshot snapshot = LdapConnectionPoolIntrospector.parse("something else entirely");
+        LdapPoolSnapshot snapshot = PoolDumpParser.parse("something else entirely");
 
         assertThat(snapshot.accessible()).isFalse();
         assertThat(snapshot.maxSize()).isZero();
-        assertThat(snapshot.forAuth("simple")).isEqualTo(AuthPoolStats.empty());
+        assertThat(snapshot.forAuth(SIMPLE)).isEqualTo(AuthPoolStats.empty());
     }
 
     @Test
@@ -176,31 +180,13 @@ class LdapConnectionPoolIntrospectorTest {
             .replace("anonymous pools:", "anonymous connection groups:")
             .replace("simple auth pools:", "simple auth connection groups:");
 
-        assertThat(LdapConnectionPoolIntrospector.parse(renamed).accessible()).isFalse();
+        assertThat(PoolDumpParser.parse(renamed).accessible()).isFalse();
     }
 
     @Test
     void aNonNumericValueFallsBackInsteadOfThrowing() {
         String garbled = POPULATED.replace("idle timeout: 300000", "idle timeout: soon");
 
-        assertThat(LdapConnectionPoolIntrospector.parse(garbled).idleTimeoutMillis()).isZero();
-    }
-
-    // --- the per-identity value extractor -----------------------------------------------------------------------
-
-    @Test
-    void extractsEachCountFromAStatsLine() {
-        String line = "host:389:::null:cn=admin:size=10; use=45; busy=2; idle=7; expired=1";
-
-        assertThat(LdapConnectionPoolIntrospector.extract(line, "size=")).isEqualTo(10);
-        assertThat(LdapConnectionPoolIntrospector.extract(line, "busy=")).isEqualTo(2);
-        assertThat(LdapConnectionPoolIntrospector.extract(line, "idle=")).isEqualTo(7);
-        assertThat(LdapConnectionPoolIntrospector.extract(line, "expired=")).isEqualTo(1);
-    }
-
-    @Test
-    void extractReturnsZeroForAMissingOrMalformedKey() {
-        assertThat(LdapConnectionPoolIntrospector.extract("size=10", "missing=")).isZero();
-        assertThat(LdapConnectionPoolIntrospector.extract("size=; idle=3", "size=")).isZero();
+        assertThat(PoolDumpParser.parse(garbled).idleTimeoutMillis()).isZero();
     }
 }

--- a/tools/ldap-metrics-realm/ldap-metrics-realm.json
+++ b/tools/ldap-metrics-realm/ldap-metrics-realm.json
@@ -1,0 +1,153 @@
+{
+  "realm": "ldap-metrics",
+  "enabled": true,
+  "components": {
+    "org.keycloak.storage.UserStorageProvider": [
+      {
+        "name": "ldap-example",
+        "providerId": "ldap",
+        "subComponents": {
+          "org.keycloak.storage.ldap.mappers.LDAPStorageMapper": [
+            {
+              "name": "username",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "user.model.attribute": [
+                  "username"
+                ],
+                "ldap.attribute": [
+                  "uid"
+                ],
+                "read.only": [
+                  "true"
+                ],
+                "always.read.value.from.ldap": [
+                  "false"
+                ],
+                "is.mandatory.in.ldap": [
+                  "true"
+                ]
+              }
+            },
+            {
+              "name": "first name",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "user.model.attribute": [
+                  "firstName"
+                ],
+                "ldap.attribute": [
+                  "cn"
+                ],
+                "read.only": [
+                  "true"
+                ],
+                "always.read.value.from.ldap": [
+                  "true"
+                ],
+                "is.mandatory.in.ldap": [
+                  "true"
+                ]
+              }
+            },
+            {
+              "name": "last name",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "user.model.attribute": [
+                  "lastName"
+                ],
+                "ldap.attribute": [
+                  "sn"
+                ],
+                "read.only": [
+                  "true"
+                ],
+                "always.read.value.from.ldap": [
+                  "true"
+                ],
+                "is.mandatory.in.ldap": [
+                  "true"
+                ]
+              }
+            },
+            {
+              "name": "email",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "user.model.attribute": [
+                  "email"
+                ],
+                "ldap.attribute": [
+                  "mail"
+                ],
+                "read.only": [
+                  "true"
+                ],
+                "always.read.value.from.ldap": [
+                  "false"
+                ],
+                "is.mandatory.in.ldap": [
+                  "false"
+                ]
+              }
+            }
+          ]
+        },
+        "config": {
+          "enabled": [
+            "true"
+          ],
+          "priority": [
+            "0"
+          ],
+          "vendor": [
+            "other"
+          ],
+          "connectionUrl": [
+            "ldap://ldap:389"
+          ],
+          "bindDn": [
+            "cn=admin,dc=example,dc=org"
+          ],
+          "bindCredential": [
+            "adminpassword"
+          ],
+          "authType": [
+            "simple"
+          ],
+          "usersDn": [
+            "ou=users,dc=example,dc=org"
+          ],
+          "usernameLDAPAttribute": [
+            "uid"
+          ],
+          "rdnLDAPAttribute": [
+            "uid"
+          ],
+          "uuidLDAPAttribute": [
+            "entryUUID"
+          ],
+          "userObjectClasses": [
+            "inetOrgPerson"
+          ],
+          "searchScope": [
+            "1"
+          ],
+          "editMode": [
+            "READ_ONLY"
+          ],
+          "importEnabled": [
+            "true"
+          ],
+          "cachePolicy": [
+            "NO_CACHE"
+          ],
+          "connectionPooling": [
+            "true"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/tools/ldap-seed.ldif
+++ b/tools/ldap-seed.ldif
@@ -1,0 +1,19 @@
+dn: ou=users,dc=example,dc=org
+objectClass: organizationalUnit
+ou: users
+
+dn: uid=alice,ou=users,dc=example,dc=org
+objectClass: inetOrgPerson
+uid: alice
+cn: Alice Example
+sn: Example
+mail: alice@example.org
+userPassword: alice
+
+dn: uid=bob,ou=users,dc=example,dc=org
+objectClass: inetOrgPerson
+uid: bob
+cn: Bob Example
+sn: Example
+mail: bob@example.org
+userPassword: bob


### PR DESCRIPTION
Adds an opt-in provider exposing `keycloak_ldap_pool_*` gauges: pool sizing, idle timeout, the number of host/port/principal groups, and connection counts by state (`total`/`idle`/`busy`/`expired`) per authentication mechanism.

Verified end-to-end against Keycloak 26.7.0 with a real OpenLDAP — a federated user search produces:

```
keycloak_ldap_pool_accessible                                         1.0
keycloak_ldap_pool_identity_pools{authentication="simple"}            1.0
keycloak_ldap_pool_connections{authentication="simple",state="total"} 1.0
keycloak_ldap_pool_connections{authentication="simple",state="idle"}  1.0
```

and each further search that cannot reuse a connection adds one.

## Read this first

**Keycloak has its own LDAP metrics, and for most deployments they are the better answer.** `--features=ldap-metrics` gives `keycloak_ldap_requests_*` (counts, latency, errors) with no extra dependency and no JVM flags. This provider covers only what that does not: **pool occupancy**. The documentation says so up front rather than burying it.

## Design

Reads `com.sun.jndi.ldap.LdapPoolManager#showStats(PrintStream)` — a *public* method in a non-exported package. One reflective handle, instead of digging through `Pool`, `ConnectionsRef` and `Connections` internals, and it needs only:

```
--add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED
```

`--add-exports` rather than `--add-opens` is deliberate and measured: only a public member is invoked, so the deep reflection `--add-opens` grants is not required. All four combinations were tested; without any flag it fails cleanly with `IllegalAccessException`.

**It fails loudly, not quietly.** Parsing a debug dump instead of an API is the real trade-off here. If not a single pool section is recognised, `keycloak_ldap_pool_accessible` reports `0` rather than a plausible-looking wall of zeros — that gauge is the one to alert on.

**Strong references on every gauge.** Micrometer keeps only a `WeakReference` to a gauge's supplier; once collected, the gauge reports `NaN` forever. Holding the binder alive does not help — the suppliers are separate objects. Verified that Keycloak 26.7 ships Micrometer 1.16.3, which has `strongReference(boolean)`.

## Testing

- 13 unit tests pinning the parser to **verbatim output of a real JDK 21 run** against OpenLDAP, rather than to an assumption about the format. Includes that a renamed section header surfaces as `accessible = 0`.
- `LdapPoolMetricsIT` scrapes the endpoint inside a running Keycloak.
- `docker-compose.ldap-metrics.yml` brings up OpenLDAP plus a Keycloak whose realm `ldap-metrics` already has the federation wired, on shifted ports so it runs next to the regular compose file.

## Notes for review

- Uses `io.micrometer:micrometer-core` as `provided` — supplied by the Keycloak distribution, never bundled.
- The realm import carries the default LDAP attribute mappers explicitly. Creating a provider through the API installs them via `LDAPStorageProviderFactory.onCreate`; a realm import bypasses that hook, and without them every user search comes back empty.
- Does not work in Keycloak's GraalVM native distribution — documented.
- `docs/developer_info.md` moves to `nav_order: 8` so it stays last, ahead of the external *Release notes* link.
