### PR TITLE
chore: pin images and actions by digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,18 @@ updates:
     labels: ["ignore-for-release", "github-actions", "dependencies"]
 
 
+  # Maintain digest pins for container images (docker-compose.yml)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "sventorben"
+    commit-message:
+      prefix: "chore"
+    labels: ["ignore-for-release", "docker", "dependencies"]
+
+
   # Maintain dependencies for maven
   - package-ecosystem: "maven"
     directory: "/"

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Set up JDK 17
-      uses: actions/setup-java@v5.7.0
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         distribution: 'temurin'
         java-version: 17
@@ -40,9 +40,9 @@ jobs:
               experimental: true
     continue-on-error: ${{ matrix.experimental }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up JDK 17
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,16 +39,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Set up JDK 17
-      uses: actions/setup-java@v5.7.0
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
           distribution: 'temurin'
           java-version: 17
           cache: 'maven'
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.6
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -62,4 +62,4 @@ jobs:
       run: mvn clean compile
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.6
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/ignore-for-release-labels.yml
+++ b/.github/workflows/ignore-for-release-labels.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Add ignore-for-release to deps-dev PRs
-                uses: actions/github-script@v9
+                uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
                 with:
                     script: |
                         const pr = context.payload.pull_request;

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -13,11 +13,11 @@ jobs:
         extension_version: [ 26.0.0 ]
     name: KC ${{ matrix.keycloak_version }}, Extension ${{ matrix.extension_version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
             ref: v${{ matrix.extension_version }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v5.7.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
     - name: Configure Git User
       run: |
         git config user.email "actions@github.com"
         git config user.name "GitHub Actions"
     - name: Set up JDK 17
-      uses: actions/setup-java@v5.7.0
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         distribution: 'temurin'
         java-version: 17
@@ -52,11 +52,11 @@ jobs:
     - name: Generate checksums
       run: cd target/checkout/target && sha256sum kommons.jar > SHA256SUMS
     - name: Attest build provenance
-      uses: actions/attest-build-provenance@v4
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
       with:
         subject-path: target/checkout/target/kommons.jar
     - name: Release to GitHub releases
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
       with:
         files: |
           target/checkout/target/kommons.jar
@@ -70,7 +70,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     - name: Create Pull Request
       id: create-pr
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
       with:
         commit-message: "chore(release): Prepare next version"
         delete-branch: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   keycloak:
     container_name: keycloak
     hostname: keycloak
-    image: quay.io/keycloak/keycloak:26.7.0
+    image: quay.io/keycloak/keycloak:26.7.0@sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13
 
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
         <!-- For compatibility tests -->
         <keycloak.version>${version.keycloak}</keycloak.version>
 
+        <!-- Digest pin for the Keycloak test image, as "<version>@sha256:<digest>". It is
+             applied only when the requested keycloak.version matches the version recorded
+             here, so the compatibility matrix keeps resolving its other versions - and the
+             floating 'latest'/'nightly' tags - by tag. -->
+        <keycloak.image.pin>26.7.0@sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13</keycloak.image.pin>
+
         <version.mockito>5.23.0</version.mockito>
         <version.testcontainers>1.21.4</version.testcontainers>
     </properties>
@@ -93,6 +99,7 @@
                             <org.jboss.logging.provider>log4j2</org.jboss.logging.provider>
                             <webdriver.remote.enableTracing>false</webdriver.remote.enableTracing>
                             <keycloak.version>${keycloak.version}</keycloak.version>
+                            <keycloak.image.pin>${keycloak.image.pin}</keycloak.image.pin>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>

--- a/src/test/java/de/sventorben/keycloak/kommons/KeycloakImage.java
+++ b/src/test/java/de/sventorben/keycloak/kommons/KeycloakImage.java
@@ -2,20 +2,37 @@ package de.sventorben.keycloak.kommons;
 
 final class KeycloakImage {
 
+    private static final String REPOSITORY = "quay.io/keycloak/keycloak";
     private static final String LATEST_VERSION = "latest";
     private static final String NIGHTLY_VERSION = "nightly";
     private static final String KEYCLOAK_VERSION = System.getProperty("keycloak.version", LATEST_VERSION);
+
+    /**
+     * Digest pin as {@code <version>@sha256:<digest>}, supplied by the build. It is applied
+     * only when it refers to the requested version, so overriding {@code keycloak.version}
+     * (as the compatibility matrix does) falls back to plain tag resolution instead of
+     * silently pulling the pinned image under a different version's name.
+     */
+    private static final String KEYCLOAK_IMAGE_PIN = System.getProperty("keycloak.image.pin", "");
 
     private final String version;
     private final String name;
 
     private KeycloakImage(String version) {
         this.version = version;
-        this.name = "quay.io/keycloak/keycloak:" + KEYCLOAK_VERSION;
+        this.name = REPOSITORY + ":" + tagFor(version);
     }
 
     public static KeycloakImage fromConfig() {
         return new KeycloakImage(KEYCLOAK_VERSION);
+    }
+
+    private static String tagFor(String version) {
+        int separator = KEYCLOAK_IMAGE_PIN.indexOf('@');
+        if (separator > 0 && KEYCLOAK_IMAGE_PIN.substring(0, separator).equals(version)) {
+            return KEYCLOAK_IMAGE_PIN;
+        }
+        return version;
     }
 
     public String getName() {


### PR DESCRIPTION
Pins every externally-resolved image and action to an immutable digest, without
losing the version information that makes the references readable.

## GitHub Actions

All 16 `uses:` references across the five workflows now point at commit SHAs,
with the version preserved in a trailing comment:

```yaml
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
```

This is the form Dependabot maintains — it rewrites the SHA *and* the comment
on a new release — so `.github/dependabot.yml` needs no change for this half.
No action versions were bumped; each SHA is what the tag resolved to at the
time of writing.

## Container image

OCI reference syntax allows a tag and a digest in the same reference. The
runtime resolves the digest and ignores the tag, so the version stays visible:

```yaml
image: quay.io/keycloak/keycloak:26.7.0@sha256:0f198be2…
```

The digest is the multi-arch **index** digest, not a per-platform manifest, so
arm64 machines still resolve correctly.

The integration tests take the same pin through the new `keycloak.image.pin`
property as `<version>@sha256:<digest>`, and `KeycloakImage` applies it only
when it refers to the version actually requested. That keeps the compatibility
matrix working untouched: overriding `keycloak.version` falls back to plain tag
resolution instead of silently pulling the 26.7.0 image under another version's
name, and `latest`/`nightly` stay floating by design.

Dependabot gains the `docker` ecosystem so the compose pin gets updated; the
maven ecosystem does not cover compose files.

## Not covered

`runs-on: ubuntu-latest` cannot be pinned to a digest. Testcontainers' Ryuk
sidecar is also still tag-resolved — it is configured outside the build, via
`TESTCONTAINERS_RYUK_CONTAINER_IMAGE` or `.testcontainers.properties`, and is
left for a separate change.

## Verification

- `OrganizationScopeEnforcerIT` passes against the pinned image (5/5).
- Confirmed the daemon resolved the pinned digest at test time, and that it is
  distinct from the locally cached `26.7.0` tag — the tag had drifted, which is
  exactly what the pin prevents.
- `docker compose config` and YAML parsing pass for all touched files.
